### PR TITLE
Fixing SS 3.1 support. Changing minimum requirement to 3.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adds support for fulltext search engines like Sphinx and Solr to SilverStripe CM
 
 ## Requirements
 
-* SilverStripe 3.0
+* SilverStripe 3.1+
 * (optional) [silverstripe-phockito](https://github.com/hafriedlander/silverstripe-phockito) (for testing)
 
 ## Documentation

--- a/code/search/SearchIntrospection.php
+++ b/code/search/SearchIntrospection.php
@@ -70,7 +70,7 @@ class SearchIntrospection {
 	 */
 	static function has_extension($class, $extension, $includeSubclasses = true) {
 		foreach (self::hierarchy($class, $includeSubclasses) as $relatedclass) {
-			if (Object::has_extension($relatedclass, $extension)) return true;
+			if ($relatedclass::has_extension($extension)) return true;
 		}
 		return false;
 	}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 	],
 	"require":
 	{
-		"silverstripe/framework": "3.*"
+		"silverstripe/framework": "3.1.*"
 	}
 }


### PR DESCRIPTION
In SilverStripe 3.1 `Object::has_extension()` doesn't have an argument fulltextsearch was relying on. As a result, you can't save a page with the fulltextsearch module installed. This fixes that to work with SilverStripe 3.1 correctly, however it also removes support for 3.0 at the same time.

Given we don't have any official release of this module, is this bump in minimum requirements to 3.1 acceptable?
