### PR TITLE
FIX Throw error if trying to add a table-less DataObject class to index

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -187,6 +187,10 @@ abstract class SearchIndex extends ViewableData {
 			throw new Exception('Can\'t add class to Index after fields have already been added');
 		}
 
+		if (!DataObject::has_own_table($class)) {
+			throw new InvalidArgumentException('Can\'t add classes which don\'t have data tables (no $db or $has_one set on the class)');
+		}
+
  		$options = array_merge(array(
 			'include_children' => true
 		), $options);


### PR DESCRIPTION
Its impossible for SearchUpdater#handle_manipulation to figure out the difference
between writing to a table-less class (like Page if theres no $db set) and the
table-having parent (like SiteTree) because it only examines the DB manipulation.

This meant if you tried to index Page (again assuming there are no $db fields on Page), only subclasses that did have $db fields would be indexed in realtime.

We cant fix, but we can throw an error if you try to do that.
