### PR TITLE
BUGFIX: Search reindex task clearing search index for subsites.

### DIFF
--- a/code/search/SearchVariantSubsites.php
+++ b/code/search/SearchVariantSubsites.php
@@ -2,6 +2,11 @@
 
 class SearchVariantSubsites extends SearchVariant {
 
+	public function __construct() {
+		//Use the session variable for current subsite when building the search index
+		Subsite::$use_session_subsiteid = true;
+	}
+
 	function appliesToEnvironment() {
 		return class_exists('Subsite');
 	}


### PR DESCRIPTION
Fixes silverstripe-labs/silverstripe-fulltextsearch#26.

Regression issue caused by this change in subsites:
https://github.com/silverstripe/silverstripe-subsites/commit/7bf6e893208ce689b45ab34a9c1de14e5d5201bf

When reindexing the subsites the session subsite ID should be used by the reindex task.