### PR TITLE
API Disable queued processing for development environments

### DIFF
--- a/_config/processor.yml
+++ b/_config/processor.yml
@@ -8,6 +8,8 @@ Injector:
 Name: messagequeueprocessor
 Only:
   ModuleExists: messagequeue
+Except:
+  Environment: 'dev'
 ---
 Injector:
   SearchUpdateProcessor:
@@ -16,6 +18,8 @@ Injector:
 Name: queuedjobprocessor
 Only:
   ModuleExists: queuedjobs
+Except:
+  Environment: 'dev'
 ---
 Injector:
   SearchUpdateProcessor:


### PR DESCRIPTION
This will eliminate issues with new developers (or old developers on new projects) complaining about fulltext search not working. It's normally not necessary to queue indexing when running locally.
