### PR TITLE
API Rate limit and caching mechanism (do not merge)

### DIFF
--- a/_config/solr.yml
+++ b/_config/solr.yml
@@ -1,0 +1,6 @@
+---
+Name: solrconfig
+---
+SolrIndex:
+  extensions:
+    - SolrQueryFilter

--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -30,6 +30,7 @@
 abstract class SearchIndex extends ViewableData {
 
 	function __construct() {
+		parent::__construct();
 		$this->init();
 
 		foreach ($this->getClasses() as $class => $options) {

--- a/code/search/processors/SearchUpdateMessageQueueProcessor.php
+++ b/code/search/processors/SearchUpdateMessageQueueProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+if(!class_exists('MessageQueue')) return;
+
 class SearchUpdateMessageQueueProcessor extends SearchUpdateProcessor {
 	/**
 	 * The MessageQueue to use when processing updates

--- a/code/search/processors/SearchUpdateProcessor.php
+++ b/code/search/processors/SearchUpdateProcessor.php
@@ -74,6 +74,3 @@ abstract class SearchUpdateProcessor {
 
 	abstract public function triggerProcessing();
 }
-
-
-

--- a/code/search/processors/SearchUpdateQueuedJobProcessor.php
+++ b/code/search/processors/SearchUpdateQueuedJobProcessor.php
@@ -1,6 +1,7 @@
 <?php
 
-
+if(!interface_exists('QueuedJob')) return;
+	
 class SearchUpdateQueuedJobProcessor extends SearchUpdateProcessor implements QueuedJob {
 
 	/**

--- a/code/solr/SolrQueryFilter.php
+++ b/code/solr/SolrQueryFilter.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Provides caching and rate limiting optimisations to {@see SolrIndex}
+ */
+class SolrQueryFilter extends Extension {
+	
+	/**
+	 * Time duration (in second) to allow for query execution. Search requests within this
+	 * time period while another query is in progress will be presented with a 429 (rate limit)
+	 * HTTP error. Once a search has completed execution then the timeout is reset to rate_cooldown
+	 * (if one is set) or zero otherwise.
+	 *
+	 * @config
+	 * @var int
+	 */
+	private static $rate_timeout = 10;
+	
+	/**
+	 * Time duration (in sections) to deny further search requests after a successful search.
+	 * Search requests within this time period while another query is in progress will be
+	 * presented with a 429 (rate limit)
+	 *
+	 * @config
+	 * @var int
+	 */
+	private static $rate_cooldown = 2;
+	
+	/**
+	 * Determine if the rate limiting should be locked on a per-query basis.
+	 *
+	 * @config
+	 * @var bool
+	 */
+	private static $rate_byquery = false;
+	
+	/**
+	 * Determine if rate limiting should be applied independently to each IP address. This method is not
+	 * always reliable protection against DDoS as most attacks use multiple IP addresses, but it does
+	 * prevent different users from being rate limited by each other.
+	 *
+	 * @config
+	 * @var bool
+	 */
+	private static $rate_byuserip = false;
+	
+	/**
+	 * True if rate limiting should be enabled
+	 * 
+	 * @config
+	 * @var bool
+	 */
+	private static $rate_enabled = true;
+	
+	/**
+	 * Number of seconds to cache results for.
+	 * 
+	 * @config
+	 * @var int
+	 */
+	private static $cache_lifetime = 300;
+	
+	/**
+	 * True if caching should be enabled
+	 * 
+	 * @config
+	 * @var bool
+	 */
+	private static $cache_enabled = true;
+	
+	/**
+	 * Gets the cache to use
+	 * 
+	 * @return Zend_Cache_Frontend
+	 */
+	public function getFilterCache() {
+		$cache = SS_Cache::factory('SolrQueryFilter');
+		$cache->setOption('automatic_serialization', true);
+		return $cache;
+	}
+	
+	/**
+	 * Determines the key to use for saving the current rate
+	 * 
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @return string Result key
+	 */
+	protected function getRateLockKey(SolrService $service, $arguments) {
+		// Distinguish this service by path
+		$entropy = $service->getPath();
+		
+		// Identify search by search query
+		if($this->owner->config()->rate_byquery) {
+			$entropy .= serialize($arguments);
+		}
+		
+		// Identify by user if configured
+		if($this->owner->config()->rate_byuserip && Controller::has_curr()) {
+			$entropy .= Controller::curr()->getRequest()->getIP();
+		}
+		
+		return 'SolrQueryFilter_Rate_' .md5($entropy);
+	}
+	
+	/**
+	 * Determines the key to use for saving cached results for a query
+	 * 
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @return string Result key
+	 */
+	protected function getCacheKey(SolrService $service, $arguments) {
+		// Distinguish this service by path
+		$entropy = $service->getPath();
+		
+		// Identify search by search query
+		$entropy .= serialize($arguments);
+		
+		// Distinguish this service by path and query arguments
+		return 'SolrQueryFilter_Cache_' . md5($entropy);
+	}
+	
+	/**
+	 * Hook called just prior to SolrService::query
+	 * 
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @return Apache_Solr_Response A resulting cached query, if available, or null otherwise
+	 * @throws SS_HTTPResponse_Exception
+	 */
+	public function onBeforeSearch(SolrService $service, $arguments) {
+		// Check for cached result
+		if($result = $this->getCachedResult($service, $arguments)) {
+			return $result;
+		}
+		
+		// Apply rate limiting rules
+		$this->applyRateLimit($service, $arguments);
+		return null;
+	}
+	
+	/**
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @param Apache_Solr_Response $serviceResult Result of either call to SolrService::query, or
+	 * the value of any cached result. This may be null if no results are available.
+	 * @param array $extendedResult The list of results returned from extend('onBeforeSearch');
+	 */
+	public function onAfterSearch(SolrService $service, $arguments, $serviceResult = null, $extendedResult = null) {
+		// We shouldn't further cache or rate limit the result of already cached results
+		if($extendedResult) return;
+		
+		// Save cached result
+		$this->setCachedResult($service, $arguments, $serviceResult);
+			
+		// Reset rate limit for this request if a non cached result was performed
+		$this->resetRateLimit($service, $arguments);
+	}
+	
+	/**
+	 * Attempt to retrieve cached results for a query
+	 * 
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @return Apache_Solr_Response A resulting cached query, if available, or null otherwise
+	 */
+	protected function getCachedResult(SolrService $service, $arguments) {
+		// Bypass caching if disabled
+		if(!$this->owner->config()->cache_enabled) return;
+		
+		// Retrieve result
+		$cache = $this->getFilterCache();
+		$cacheKey = $this->getCacheKey($service, $arguments);
+		return $cache->load($cacheKey);
+	}
+	
+	/**
+	 * Save cached results
+	 * 
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @param Apache_Solr_Response $serviceResult Result of either call to SolrService::query, or
+	 * the value of any cached result. This may be null if no results are available.
+	 */
+	protected function setCachedResult(SolrService $service, $arguments, $serviceResult) {
+		// Bypass caching if disabled
+		if(!$this->owner->config()->cache_enabled || empty($serviceResult)) return;
+		
+		// Store result
+		$cache = $this->getFilterCache();
+		$cacheKey = $this->getCacheKey($service, $arguments);
+		$cacheLifetime = $this->owner->config()->cache_lifetime;
+		$cache->save($serviceResult, $cacheKey, array(), $cacheLifetime);
+	}
+
+
+	/**
+	 * Applies rate limiting rules to this query
+	 * 
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 * @throws SS_HTTPResponse_Exception
+	 */
+	protected function applyRateLimit(SolrService $service, $arguments) {
+		// Bypass rate limiting if disabled
+		if(!$this->owner->config()->rate_enabled) return;
+		
+		// Generate result with rate limiting enabled
+		$limitKey = $this->getRateLockKey($service, $arguments);
+		$cache = $this->getFilterCache();
+		if($lockedUntil = $cache->load($limitKey)) {
+			if(time() < $lockedUntil) {
+				// Politely inform visitor of limit
+				$response = new SS_HTTPResponse_Exception('Too Many Requests.', 429);
+				$response->getResponse()->addHeader('Retry-After', 1 + $lockedUntil - time());
+				throw $response;
+			}
+		}
+		
+		// Lock this query for $timeout seconds
+		$timeout = $this->owner->config()->rate_timeout;
+		$cache->save(time() + $timeout, $limitKey);
+	}
+	
+	/**
+	 * @param SolrService $service Source service to query
+	 * @param array $arguments Arguments to be passed to SolrService::query
+	 */
+	protected function resetRateLimit(SolrService $service, $arguments) {
+		// Bypass rate limiting if disabled
+		if(!$this->owner->config()->rate_enabled) return;
+		
+		// After search is performed, reset lock timeout to an appropriate time
+		$limitKey = $this->getRateLockKey($service, $arguments);
+		$cache = $this->getFilterCache();
+		
+		if($cooldown = $this->owner->config()->rate_cooldown) {
+			// Set cooldown on successful query execution
+			$cache->save(time() + $cooldown, $limitKey);
+		} else {
+			// Without cooldown simply disable lock
+			$cache->remove($limitKey);
+		}
+	}
+}

--- a/docs/en/Solr.md
+++ b/docs/en/Solr.md
@@ -360,6 +360,63 @@ see `thirdparty/fulltextsearch/server/silverstripe-solr-test.xml`.
 
 	java -Durl=http://localhost:8983/solr/MyIndex/update/ -Dtype=text/xml -jar post.jar silverstripe-solr-test.xml
 
+## Optimising Performance
+
+Fulltext search comes with an optional caching and rate limiting mechanism for Solr.
+This allows users to cache the results of queries and apply rate limiting rules.
+
+### Caching
+
+By default queries are cached for 5 minutes. You can customise the caching for any index by applying
+the following config
+
+	:::yaml
+	MyIndex:
+		# Cache queries for 5 minutes
+		cache_lifetime: 300
+
+
+Caching can be disabled as well.
+
+	:::yaml
+	MyIndex:
+		cache_enabled: false
+
+
+### Rate Limiting
+
+This feature allows limits to be applied to uncached queries (queries that hit the solr search store). There is
+a separate limit for queries in progress, as well as a 'cooldown' feature which blocks subsequent queries for
+a period of time.
+
+Users who receive a rate limit notification will be presented with a 429 (Too Many Requests) HTTP error.
+This may be customised with a 429 `ErrorPage`.
+
+Rate limiting for indexes can be configured as below:
+
+	:::yaml
+	MyIndex:
+		# The maximum number of seconds to allow for queries to execute. If a query exceeds this number of seconds
+		# to execute, then the rate limit will be reset, allowing requests again. If a query is in progress
+		# prior to this timeout being reached, requests will be met with a rate limit 429 error.
+		rate_timeout: 10
+		# If a query has finished then continue to block requests for this number of seconds afterwards
+		rate_cooldown: 2
+		# Force rate limiting across all queries. 'true' would mean only rate limit for other attempts
+		# to execute the same query.
+		rate_byquery: false
+		# Force rate limiting across all users. 'true' would mean only rate limit for attempts by the same
+		# person, identified by IP address.
+		rate_byuserip: false
+
+
+Rate limiting can be disabled as well.
+
+	:::yaml
+	MyIndex:
+		rate_enabled: false
+
+
 ## FAQ
 
 ### How do I use date ranges where dates might not be defined?

--- a/tests/SolrQueryFilterTest.php
+++ b/tests/SolrQueryFilterTest.php
@@ -1,0 +1,263 @@
+<?php
+
+if (class_exists('Phockito')) Phockito::include_hamcrest();
+
+/**
+ * Description of SolrQueryFilterTest
+ *
+ * @author dmooyman
+ */
+class SolrQueryFilterTest extends SapphireTest {
+	
+	protected $extraDataObjects = array(
+		'SearchUpdaterTest_Container'
+	);
+	
+	protected static $fixture_file = 'SolrQueryFilterTest.yml';
+
+	public function setUp() {
+		parent::setUp();
+		
+		if (!class_exists('Phockito')) {
+			$this->skipTest = true;
+			return $this->markTestSkipped("These tests need the Phockito module installed to run");
+		}
+		
+		// flush cache
+		$cache = $this->getFilterCache();
+		$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
+	}
+	
+	protected function getFilterCache() {
+		return singleton('SolrQueryFilterTest_BaseIndex')->getFilterCache();
+	}
+
+	protected function getServiceMock($operations) {
+		$service = Phockito::mock('Solr3Service');
+		foreach($operations as $input => $items) {
+			$response = $this->getResponseMock($items);
+			Phockito::when($service->search($input, anything(), anything(), anything(), anything()))
+				->return($response);
+		}
+		return $service;
+	}
+	
+	protected function getResponseMock($items) {
+		$response = Phockito::mock('Apache_Solr_Response');
+		Phockito::when($response->getHttpStatus())->return(200);
+		$response->response = new stdClass();
+		$response->response->numFound = count($items);
+		$response->response->docs = $items;
+		return $response;
+	}
+	
+	/**
+	 * Performs a search using the relevant text
+	 * 
+	 * @param SolrQueryFilterTest_BaseIndex $index
+	 * @param string $text
+	 * @return ArrayData
+	 */
+	protected function doSearch($index, $text) {
+		$query = new SearchQuery();
+		$query->search($text);
+		return $index->search($query);
+	}
+	
+	/**
+	 * Helper function for testCaching()
+	 * 
+	 * @param SolrQueryFilterTest_BaseIndex $index
+	 * @param SearchUpdaterTest_Container $first Expected results of search for 'Just First'
+	 * @param SearchUpdaterTest_Container $second Expected results of search for 'Get Second'
+	 */
+	protected function checkResults($index, $first, $second) {
+		// Cache search for first item
+		$result1 = $this->doSearch($index, 'Just First');
+		$this->assertEquals(1, $result1->Matches->count());
+		$this->assertEquals($first->ID, $result1->Matches->first()->ID);
+		$this->assertEquals('SearchUpdaterTest_Container', $result1->Matches->first()->ClassName);
+		
+		// Cache search for second item
+		$result2 = $this->doSearch($index, 'Get Second');
+		$this->assertEquals(1, $result2->Matches->count());
+		$this->assertEquals($second->ID, $result2->Matches->first()->ID);
+		$this->assertEquals('SearchUpdaterTest_Container', $result2->Matches->last()->ClassName);
+	}
+	
+	public function testCaching() {
+		// Setup mocks
+		$item1 = $this->objFromFixture('SearchUpdaterTest_Container', 'item1');
+		$item2 = $this->objFromFixture('SearchUpdaterTest_Container', 'item2');
+		$item3 = $this->objFromFixture('SearchUpdaterTest_Container', 'item3');
+		$service = $this->getServiceMock(array(
+			'+Just +First' => array($item1),
+			'+Get +Second' => array($item2),
+			'+Get +Both' => array($item1, $item2)
+		));
+		$index = singleton('SolrQueryFilterTest_CachedIndex');
+		$index->setService($service);
+		
+		// Do initial search (note that 'Get Both' is never called)
+		$this->checkResults($index, $item1, $item2);
+		
+		// Change behaviour of service to see if cached results are still returned
+		$service = $this->getServiceMock(array(
+			'+Just +First' => array($item2),
+			'+Get +Second' => array($item3),
+			'+Get +Both' => array($item2, $item3)
+		));
+		$index->setService($service);
+		$this->checkResults($index, $item1, $item2);
+		
+		// Search for 'Get Both' to make sure an uncached hit still gets through
+		$bothResult = $this->doSearch($index, 'Get Both');
+		$this->assertEquals(2, $bothResult->Matches->count());
+		$this->assertEquals($item2->ID, $bothResult->Matches->first()->ID);
+		$this->assertEquals($item3->ID, $bothResult->Matches->last()->ID);
+	}
+	
+	public function testRateLimiting() {
+		
+		// Setup mocks
+		$item1 = $this->objFromFixture('SearchUpdaterTest_Container', 'item1');
+		$item2 = $this->objFromFixture('SearchUpdaterTest_Container', 'item2');
+		$service = $this->getServiceMock(array(
+			'+Just +First' => array($item1),
+			'+Get +Second' => array($item2)
+		));
+		$index = singleton('SolrQueryFilterTest_RateIndex');
+		$index->setService($service);
+		
+		// Ensure initial request doesn't hit the rate limit
+		$result1 = $this->doSearch($index, 'Just First');
+		$this->assertEquals(1, $result1->Matches->count());
+		$this->assertEquals($item1->ID, $result1->Matches->first()->ID);
+		
+		// Subsequent requests should hit the cooldown limit
+		$exception = null;
+		try {
+			$this->doSearch($index, 'Get Second');
+		} catch(SS_HTTPResponse_Exception $ex) {
+			$exception = $ex;
+		}
+		$this->assertInstanceOf('SS_HTTPResponse_Exception', $exception);
+		$this->assertEquals(429, $exception->getResponse()->getStatusCode());
+		$this->assertGreaterThan(0, $exception->getResponse()->getHeader('Retry-After'));
+	}
+	
+	/**
+	 * Test filter with both cache and rate limit applied
+	 */
+	public function testCachedRateLimit() {
+		
+		// Setup mocks
+		$item1 = $this->objFromFixture('SearchUpdaterTest_Container', 'item1');
+		$item2 = $this->objFromFixture('SearchUpdaterTest_Container', 'item2');
+		$item3 = $this->objFromFixture('SearchUpdaterTest_Container', 'item3');
+		$service = $this->getServiceMock(array(
+			'+Just +First' => array($item1),
+			'+Get +Second' => array($item2),
+			'+The +Third' => array($item3)
+		));
+		$index = singleton('SolrQueryFilterTest_CachedRateIndex');
+		$index->setService($service);
+		
+		// Ensure initial request doesn't hit the rate limit
+		$result1 = $this->doSearch($index, 'Just First');
+		$this->assertEquals(1, $result1->Matches->count());
+		$this->assertEquals($item1->ID, $result1->Matches->first()->ID);
+		
+		// Subsequent requests should hit the cooldown limit
+		$exception = null;
+		try {
+			$this->doSearch($index, 'Get Second');
+		} catch(SS_HTTPResponse_Exception $ex) {
+			$exception = $ex;
+		}
+		$this->assertInstanceOf('SS_HTTPResponse_Exception', $exception);
+		$this->assertEquals(429, $exception->getResponse()->getStatusCode());
+		$this->assertGreaterThan(0, $exception->getResponse()->getHeader('Retry-After'));
+		
+		// Test that requests to the initial service hit the cache, and therefore bypass the rate limit
+		$result1 = $this->doSearch($index, 'Just First');
+		$this->assertEquals(1, $result1->Matches->count());
+		$this->assertEquals($item1->ID, $result1->Matches->first()->ID);
+		
+		// Test that this cache maintains its value even after service behavioural changes
+		$service = $this->getServiceMock(array(
+			'+Just +First' => array($item3),
+			'+Get +Second' => array($item1),
+			'+The +Third' => array($item2, $item1)
+		));
+		$index->setService($service);
+		$result1 = $this->doSearch($index, 'Just First');
+		$this->assertEquals(1, $result1->Matches->count());
+		$this->assertEquals($item1->ID, $result1->Matches->first()->ID);
+		
+		// Rate limiting still influences requests to uncached results
+		$exception = null;
+		try {
+			$this->doSearch($index, 'The Third');
+		} catch(SS_HTTPResponse_Exception $ex) {
+			$exception = $ex;
+		}
+		$this->assertInstanceOf('SS_HTTPResponse_Exception', $exception);
+		$this->assertEquals(429, $exception->getResponse()->getStatusCode());
+		$this->assertGreaterThan(0, $exception->getResponse()->getHeader('Retry-After'));
+	}
+}
+
+class SolrQueryFilterTest_BaseIndex extends SolrIndex {
+
+	public function init() {
+		$this->addClass('SearchUpdaterTest_Container');
+
+		$this->addFilterField('Field1');
+		$this->addFilterField('MyDate', 'Date');
+		$this->addFilterField('HasOneObject.Field1');
+		$this->addFilterField('HasManyObjects.Field1');
+	}
+}
+
+class SolrQueryFilterTest_CachedIndex extends SolrQueryFilterTest_BaseIndex {
+	
+	private static $rate_enabled = false;
+	
+	private static $cache_enabled = true;
+	
+	private static $cache_lifetime = 1000;
+}
+
+class SolrQueryFilterTest_RateIndex extends SolrQueryFilterTest_BaseIndex {
+	
+	private static $cache_enabled = false;
+	
+	private static $rate_enabled = true;
+	
+	private static $rate_byuserip = false;
+	
+	private static $rate_byquery = false;
+	
+	private static $rate_timeout = 10;
+	
+	private static $rate_cooldown = 10;
+}
+
+
+class SolrQueryFilterTest_CachedRateIndex extends SolrQueryFilterTest_BaseIndex {
+	
+	private static $cache_lifetime = 1000;
+	
+	private static $cache_enabled = true;
+	
+	private static $rate_enabled = true;
+	
+	private static $rate_byuserip = false;
+	
+	private static $rate_byquery = false;
+	
+	private static $rate_timeout = 10;
+	
+	private static $rate_cooldown = 10;
+}

--- a/tests/SolrQueryFilterTest.yml
+++ b/tests/SolrQueryFilterTest.yml
@@ -1,0 +1,10 @@
+SearchUpdaterTest_Container:
+  item1:
+    Field1: 'First'
+    Field2: 'Second'
+  item2:
+    Field1: 'Alpha'
+    Field2: 'Bravo'
+  item3:
+    Field1: 'Electrode'
+    Field2: 'Diglett'


### PR DESCRIPTION
This update creates an optional extension to SolrIndex (which may be applied on a per-index basis if necessary) to apply caching and rate limiting features to searches.

There is also a cooldown limit feature which will block further searches after the completion of a successful search, designed to rate limit users to a reasonable level, even if the server is responding in a timely fashion. The default for this value is set to 1 second, which is pretty minimal but can be increased.

This PR is an in-progress snapshot, designed to help support direction and development of this feature.

By default this extension is not added to any index, and should be enabled on an as-needed basis.

Documentation and test cases still to come.

cc @hafriedlander if you would like to make any comments on this.

ref: CWPBUG-44
