### PR TITLE
BUG Fix subsite document ID generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
 
-language: php 
+language: php
+
 php: 
  - 5.3
 
@@ -11,11 +12,16 @@ matrix:
   include:
     - php: 5.3
       env: DB=PGSQL CORE_RELEASE=3.1
+    - php: 5.3
+      env: DB=MYSQL CORE_RELEASE=3.1 SUBSITES=1
 
 before_script:
+ - composer self-update
+ - phpenv rehash
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
- - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+ - "if [ \"$SUBSITES\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
+ - "if [ \"$SUBSITES\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/subsites; fi"
  - cd ~/builds/ss
 
 script: 
- - phpunit fulltextsearch/tests/
+ - vendor/bin/phpunit fulltextsearch/tests/

--- a/code/search/SearchVariantSubsites.php
+++ b/code/search/SearchVariantSubsites.php
@@ -16,15 +16,15 @@ class SearchVariantSubsites extends SearchVariant {
 	}
 
 	function currentState() {
-		 return Subsite::currentSubsiteID();
+		 return (string)Subsite::currentSubsiteID();
 	}
 
 	function reindexStates() {
 		static $ids = null;
 
 		if ($ids === null) {
-			$ids = array(0);
-			foreach (DataObject::get('Subsite') as $subsite) $ids[] = $subsite->ID;
+			$ids = array('0');
+			foreach (DataObject::get('Subsite') as $subsite) $ids[] = (string)$subsite->ID;
 		}
 
 		return $ids;
@@ -77,7 +77,7 @@ class SearchVariantSubsites extends SearchVariant {
 
 			foreach ($write['statefulids'] as $i => $statefulid) {
 				foreach (self::$subsites as $subsiteID) {
-					$next[] = array('id' => $statefulid['id'], 'state' => array_merge($statefulid['state'], array($self => $subsiteID)));
+					$next[] = array('id' => $statefulid['id'], 'state' => array_merge($statefulid['state'], array($self => (string)$subsiteID)));
 				}
 			}
 

--- a/docs/en/changelogs/1.0.3.md
+++ b/docs/en/changelogs/1.0.3.md
@@ -4,7 +4,8 @@
 
 Users upgrading from 1.0.2 or below will need to run the Solr_Reindex task to refresh
 each SolrIndex. This is due to a change in record IDs, which are now generated from
-the base class of each DataObject, rather than the instance class.
+the base class of each DataObject, rather than the instance class, as well as fixes
+to integration with the subsites module.
 
 Developers working locally should be aware that by default, all indexes will be updated
 in realtime when the environment is in dev mode, rather than attempting to queue these

--- a/tests/SolrIndexVersionedTest.php
+++ b/tests/SolrIndexVersionedTest.php
@@ -54,6 +54,11 @@ class SolrIndexVersionedTest extends SapphireTest {
 		return Phockito::mock('Solr3Service');
 	}
 	
+	protected function getExpectedDocumentId($id, $stage) {
+		// Prevent subsites from breaking tests
+		$subsites = class_exists('Subsite') ? '"SearchVariantSubsites":"0",' : '';
+		return $id.'-SiteTree-{'.$subsites.'"SearchVariantVersioned":"'.$stage.'"}';
+	}
 	
 	public function testPublishing() {
 		
@@ -68,7 +73,7 @@ class SolrIndexVersionedTest extends SapphireTest {
 		$item->write();
 		SearchUpdater::flush_dirty_indexes();
 		$doc = new SolrDocumentMatcher(array(
-			'_documentid' => $item->ID.'-SiteTree-{"SearchVariantVersioned":"Stage"}',
+			'_documentid' => $this->getExpectedDocumentId($item->ID, 'Stage'),
 			'ClassName' => 'SearchVariantVersionedTest_Item'
 		));
 		Phockito::verify($serviceMock)->addDocument($doc);
@@ -81,7 +86,7 @@ class SolrIndexVersionedTest extends SapphireTest {
 		$item->publish('Stage', 'Live');
 		SearchUpdater::flush_dirty_indexes();
 		$doc = new SolrDocumentMatcher(array(
-			'_documentid' => $item->ID.'-SiteTree-{"SearchVariantVersioned":"Live"}',
+			'_documentid' => $this->getExpectedDocumentId($item->ID, 'Live'),
 			'ClassName' => 'SearchVariantVersionedTest_Item'
 		));
 		Phockito::verify($serviceMock)->addDocument($doc);
@@ -104,9 +109,9 @@ class SolrIndexVersionedTest extends SapphireTest {
 		$item->delete();
 		SearchUpdater::flush_dirty_indexes();
 		Phockito::verify($serviceMock, 1)
-			->deleteById($id.'-SiteTree-{"SearchVariantVersioned":"Live"}');
+			->deleteById($this->getExpectedDocumentId($id, 'Live'));
 		Phockito::verify($serviceMock, 0)
-			->deleteById($id.'-SiteTree-{"SearchVariantVersioned":"Stage"}');
+			->deleteById($this->getExpectedDocumentId($id, 'Stage'));
 		
 		// Delete the stage record
 		Versioned::reading_stage('Stage');
@@ -118,9 +123,9 @@ class SolrIndexVersionedTest extends SapphireTest {
 		$item->delete();
 		SearchUpdater::flush_dirty_indexes();
 		Phockito::verify($serviceMock, 1)
-			->deleteById($id.'-SiteTree-{"SearchVariantVersioned":"Stage"}');
+			->deleteById($this->getExpectedDocumentId($id, 'Stage'));
 		Phockito::verify($serviceMock, 0)
-			->deleteById($id.'-SiteTree-{"SearchVariantVersioned":"Live"}');
+			->deleteById($this->getExpectedDocumentId($id, 'Live'));
 	}
 }
 


### PR DESCRIPTION
Because `json_encode` would encode subsite id 0 (int) differently to subsite id "0" (string), records would occasionally not match when saving against any subsite.
