### PR TITLE
API SearchUpdateQueuedJobProcessor now uses batching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,16 @@ matrix:
       env: DB=PGSQL CORE_RELEASE=3.1
     - php: 5.3
       env: DB=MYSQL CORE_RELEASE=3.1 SUBSITES=1
+    - php: 5.3
+      env: DB=MYSQL CORE_RELEASE=3.1 QUEUEDJOBS=1 
 
 before_script:
  - composer self-update
  - phpenv rehash
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
- - "if [ \"$SUBSITES\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
+ - "if [ \"$SUBSITES\" = \"\" -a \"$QUEUEDJOBS\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
  - "if [ \"$SUBSITES\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/subsites; fi"
+ - "if [ \"$QUEUEDJOBS\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/queuedjobs; fi"
  - cd ~/builds/ss
 
 script: 

--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -573,4 +573,8 @@ abstract class SearchIndex_Recording extends SearchIndex {
 
 	function commit() { }
 	
+	function getIndexName() {
+		return get_class($this);
+	}
+	
 }

--- a/code/search/processors/SearchUpdateBatchedProcessor.php
+++ b/code/search/processors/SearchUpdateBatchedProcessor.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Provides batching of search updates
+ */
+abstract class SearchUpdateBatchedProcessor extends SearchUpdateProcessor {
+	
+	/**
+	 * List of batches to be processed
+	 *
+	 * @var array
+	 */
+	protected $batches;
+	
+	/**
+	 * Pointer to index of $batches assigned to $current.
+	 * Set to 0 (first index) if not started, or count + 1 if completed.
+	 *
+	 * @var int
+	 */
+	protected $currentBatch;
+	
+	/**
+	 * List of indexes successfully comitted in the current batch
+	 * 
+	 * @var array
+	 */
+	protected $completedIndexes;
+	
+	/**
+	 * Maximum number of record-states to process in one batch.
+	 * Set to zero to process all records in a single batch
+	 *
+	 * @config
+	 * @var int
+	 */
+	private static $batch_size = 100;
+	
+	/**
+	 * Up to this number of additional ids can be added to any batch in order to reduce the number
+	 * of batches
+	 * 
+	 * @config
+	 * @var int
+	 */
+	private static $batch_soft_cap = 10;
+	
+	public function __construct() {
+		parent::__construct();
+		
+		$this->batches = array();
+		$this->setBatch(0);
+	}
+	
+	protected function commitIndex($index) {
+		$name = $index->getIndexName();
+		
+		// If this is a resurrected batch then it's not necessary to commit the index
+		// twice, assuming it has successfully been comitted before
+		if(isset($this->completedIndexes[$name])) return true;
+		
+		// Commit index and mark as completed
+		$result = parent::commitIndex($index);
+		if($result) $this->completedIndexes[$name] = $name;
+		return $result;
+	}
+	
+	/**
+	 * Set the current batch index
+	 * 
+	 * @param int $batch Index of the batch
+	 */
+	protected function setBatch($batch) {
+		$this->currentBatch = $batch;
+		$this->completedIndexes = array();
+	}
+	
+	protected function getSource() {
+		if(isset($this->batches[$this->currentBatch])) {
+			return $this->batches[$this->currentBatch];
+		}
+	}
+	
+	/**
+	 * Process the current queue
+	 * 
+	 * @return boolean
+	 */
+	public function process() {
+		// Skip blank queues
+		if(empty($this->batches)) return true;
+		
+		// Don't re-process completed queue
+		if($this->currentBatch >= count($this->batches)) return true;
+		
+		// Process batch
+		$result = parent::process();
+		
+		// Advance to next batch if successful
+		if($result) $this->setBatch($this->currentBatch + 1);
+		return $result;
+	}
+	
+	/**
+	 * Segments batches acording to the specified rules
+	 * 
+	 * @param array $source Source input
+	 * @return array Batches
+	 */
+	protected function segmentBatches($source) {
+		// Measure batch_size
+		$batchSize = Config::inst()->get(get_class(), 'batch_size');
+		if($batchSize === 0) return array($source);
+		$softCap = Config::inst()->get(get_class(), 'batch_soft_cap');
+		
+		// Clear batches
+		$batches = array();
+		$current = array();
+		$currentSize = 0;
+
+		// Build batches from data
+		foreach ($source as $base => $statefulids) {
+			if (!$statefulids) continue;
+
+			foreach ($statefulids as $stateKey => $statefulid) {
+				$state = $statefulid['state'];
+				$ids = $statefulid['ids'];
+				if(!$ids) continue;
+				
+				// Extract items from $ids until empty
+				while($ids) {
+					// Estimate maximum number of items to take for this iteration, allowing for the soft cap
+					$take = $batchSize - $currentSize;
+					if(count($ids) <= $take + $softCap) $take += $softCap;
+					$items = array_slice($ids, 0, $take, true);
+					$ids = array_slice($ids, count($items), null, true);
+					
+					// Update batch
+					$currentSize += count($items);
+					$merge = array(
+						$base => array(
+							$stateKey => array(
+								'state' => $state,
+								'ids' => $items
+							)
+						)
+					);
+					$current = $current ? array_merge_recursive($current, $merge) : $merge;
+					if($currentSize >= $batchSize) {
+						$batches[] = $current;
+						$current = array();
+						$currentSize = 0;
+					}
+				}
+			}
+		}
+		// Add incomplete batch
+		if($currentSize) $batches[] = $current;
+		
+		return $batches;
+	}
+	
+	public function batchData() {
+		$this->batches = $this->segmentBatches($this->dirty);
+		$this->setBatch(0);
+	}
+	
+	public function triggerProcessing() {
+		$this->batchData();
+	}
+}

--- a/tests/BatchedProcessorTest.php
+++ b/tests/BatchedProcessorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+
+class BatchedProcessorTest_Object extends SiteTree implements TestOnly {
+	private static $db = array(
+		'TestText' => 'Varchar'
+	);
+}
+
+class BatchedProcessorTest_Index extends SearchIndex_Recording implements TestOnly {
+	function init() {
+		$this->addClass('BatchedProcessorTest_Object');
+		$this->addFilterField('TestText');
+	}
+}
+
+/**
+ * Tests {@see SearchUpdateQueuedJobProcessor}
+ */
+class BatchedProcessorTest extends SapphireTest {
+	
+	protected $oldProcessor;
+	
+	protected $extraDataObjects = array(
+		'BatchedProcessorTest_Object'
+	);
+
+	public function setUp() {
+		parent::setUp();
+		Config::nest();
+		
+		if (!interface_exists('QueuedJob')) {
+			$this->markTestSkipped("These tests need the QueuedJobs module installed to run");
+			$this->skipTest = true;
+		}
+		
+		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_size', 5);
+		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_soft_cap', 0);
+		
+		Versioned::reading_stage("Stage");
+		
+		$this->oldProcessor = SearchUpdater::$processor;
+		SearchUpdater::$processor = new SearchUpdateQueuedJobProcessor();
+	}
+	
+	public function tearDown() {
+		
+		SearchUpdater::$processor = $this->oldProcessor;
+		Config::unnest();
+		parent::tearDown();
+	}
+	
+	protected function generateDirtyIds() {
+		$processor = SearchUpdater::$processor;
+		for($id = 1; $id <= 42; $id++) {
+			// Save to db
+			$object = new BatchedProcessorTest_Object();
+			$object->TestText = 'Object ' . $id;
+			$object->write();
+			// Add to index manually
+			$processor->addDirtyIDs(
+				'BatchedProcessorTest_Object',
+				array(array(
+					'id' => $id,
+					'state' => array('SearchVariantVersioned' => 'Stage')
+				)),
+				'BatchedProcessorTest_Index'
+			);
+		}
+		$processor->batchData();
+		return $processor;
+	}
+	
+	/**
+	 * Tests that large jobs are broken up into a suitable number of batches
+	 */
+	public function testBatching() {
+		$index = singleton('BatchedProcessorTest_Index');
+		$index->reset();
+		$processor = $this->generateDirtyIds();
+		
+		// Check initial state
+		$data = $processor->getJobData();
+		$this->assertEquals(9, $data->totalSteps);
+		$this->assertEquals(0, $data->currentStep);
+		$this->assertEmpty($data->isComplete);
+		$this->assertEquals(0, count($index->getAdded()));
+		
+		// Advance state
+		for($pass = 1; $pass <= 8; $pass++) {
+			$processor->process();
+			$data = $processor->getJobData();
+			$this->assertEquals($pass, $data->currentStep);
+			$this->assertEquals($pass * 5, count($index->getAdded()));
+		}
+		
+		// Last run should have two hanging items
+		$processor->process();
+		$data = $processor->getJobData();
+		$this->assertEquals(9, $data->currentStep);
+		$this->assertEquals(42, count($index->getAdded()));
+		$this->assertTrue($data->isComplete);
+	}
+	
+	/**
+	 * Tests that the batch_soft_cap setting is properly respected
+	 */
+	public function testSoftCap() {
+		$index = singleton('BatchedProcessorTest_Index');
+		$index->reset();
+		$processor = $this->generateDirtyIds();
+		
+		// Test that increasing the soft cap to 2 will reduce the number of batches
+		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_soft_cap', 2);
+		$processor->batchData();
+		$data = $processor->getJobData();
+		//Debug::dump($data);die;
+		$this->assertEquals(8, $data->totalSteps);
+		
+		// A soft cap of 1 should not fit in the hanging two items
+		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_soft_cap', 1);
+		$processor->batchData();
+		$data = $processor->getJobData();
+		$this->assertEquals(9, $data->totalSteps);
+		
+		// Extra large soft cap should fit both items
+		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_soft_cap', 4);
+		$processor->batchData();
+		$data = $processor->getJobData();
+		$this->assertEquals(8, $data->totalSteps);
+		
+		// Process all data and ensure that all are processed adequately
+		for($pass = 1; $pass <= 8; $pass++) {
+			$processor->process();
+		}
+		$data = $processor->getJobData();
+		$this->assertEquals(8, $data->currentStep);
+		$this->assertEquals(42, count($index->getAdded()));
+		$this->assertTrue($data->isComplete);
+	}
+}


### PR DESCRIPTION
While the queued jobs module doesn't have an ability for jobs to suppress themselves between batch runs, breaking a job into multiple steps (one run after one another) will allow the `QueuedJobsService` to check `isMemoryTooHigh` between each batch, and will continue at the next batch in a subsequent run if memory usage becomes too high.

If this doesn't solve the problem of jobs fatally using excessive resources, then it may be necessary to extend QueuedJobs to allow jobs to decide themselves when further processing should be delayed.

Some refactor of `SearchUpdateProcessor` was done in order to better support subclasses overriding specific methods.

Graceful recovery of partially completed batches is enabled so that if a batch contains multiple indexes, then it won't attempt to re-process successfully processed indexes for that batch.
