### PR TITLE
BUG Fix Solr 4.0 compatibility issue

### DIFF
--- a/code/solr/Solr4Service.php
+++ b/code/solr/Solr4Service.php
@@ -17,6 +17,38 @@ class Solr4Service_Core extends SolrService_Core {
 		$rawPost = '<commit expungeDeletes="' . $expungeValue . '" waitSearcher="' . $searcherValue . '" />';
 		return $this->_sendRawPost($this->_updateUrl, $rawPost, $timeout);
 	}
+	
+	/**
+	 * @inheritdoc	
+	 * @see Solr4Service_Core::addDocuments
+	 */
+	public function addDocument(Apache_Solr_Document $document, $allowDups = false,
+		$overwritePending = true, $overwriteCommitted = true, $commitWithin = 0
+	) {
+		return $this->addDocuments(array($document), $allowDups, $overwritePending, $overwriteCommitted, $commitWithin);
+	}
+
+	/**
+	 * Solr 4.0 compat http://wiki.apache.org/solr/UpdateXmlMessages#Optional_attributes_for_.22add.22
+	 * Remove allowDups, overwritePending and overwriteComitted
+	 */
+	public function addDocuments($documents, $allowDups = false, $overwritePending = true,
+		$overwriteCommitted = true, $commitWithin = 0
+	) {
+		$overwriteVal = $allowDups ? 'false' : 'true';
+		$commitWithin = (int) $commitWithin;
+		$commitWithinString = $commitWithin > 0 ? " commitWithin=\"{$commitWithin}\"" : '';
+
+		$rawPost = "<add overwrite=\"{$overwriteVal}\"{$commitWithinString}>";
+		foreach ($documents as $document) {
+			if ($document instanceof Apache_Solr_Document) {
+				$rawPost .= $this->_documentToXmlFragment($document);
+			}
+		}
+		$rawPost .= '</add>';
+
+		return $this->add($rawPost);
+	}
 }
 
 class Solr4Service extends SolrService {

--- a/tests/Solr4ServiceTest.php
+++ b/tests/Solr4ServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Test solr 4.0 compatibility
+ */
+class Solr4ServiceTest extends SapphireTest {
+	
+	/**
+	 * 
+	 * @return Solr4ServiceTest_RecordingService
+	 */
+	protected function getMockService() {
+		return new Solr4ServiceTest_RecordingService();
+	}
+	
+	protected function getMockDocument($id) {
+		$document = new Apache_Solr_Document();
+		$document->setField('id', $id);
+		$document->setField('title', "Item $id");
+		return $document;
+	}
+	
+	public function testAddDocument() {
+		$service = $this->getMockService();
+		$sent = $service->addDocument($this->getMockDocument('A'), false);
+		$this->assertEquals(
+			'<add overwrite="true"><doc><field name="id">A</field><field name="title">Item A</field></doc></add>',
+			$sent
+		);
+		$sent = $service->addDocument($this->getMockDocument('B'), true);
+		$this->assertEquals(
+			'<add overwrite="false"><doc><field name="id">B</field><field name="title">Item B</field></doc></add>',
+			$sent
+		);
+	}
+	
+	public function testAddDocuments() {
+		$service = $this->getMockService();
+		$sent = $service->addDocuments(array(
+			$this->getMockDocument('C'),
+			$this->getMockDocument('D')
+		), false);
+		$this->assertEquals(
+			'<add overwrite="true"><doc><field name="id">C</field><field name="title">Item C</field></doc><doc><field name="id">D</field><field name="title">Item D</field></doc></add>',
+			$sent
+		);
+		$sent = $service->addDocuments(array(
+			$this->getMockDocument('E'),
+			$this->getMockDocument('F')
+		), true);
+		$this->assertEquals(
+			'<add overwrite="false"><doc><field name="id">E</field><field name="title">Item E</field></doc><doc><field name="id">F</field><field name="title">Item F</field></doc></add>',
+			$sent
+		);
+	}
+}
+
+class Solr4ServiceTest_RecordingService extends Solr4Service_Core {
+	protected function _sendRawPost($url, $rawPost, $timeout = FALSE, $contentType = 'text/xml; charset=UTF-8') {
+		return $rawPost;
+	}
+	
+	protected function _sendRawGet($url, $timeout = FALSE) {
+		return $url;
+	}
+}


### PR DESCRIPTION
This resolves issues with the deprecated allowDups, overwritePending and overwriteComitted properties appearing in error logs in Solr 4.0.

[ref:CWPBUG-162]
