### PR TITLE
BUG Fix test case not elegantly failing on missing phockito

### DIFF
--- a/tests/SolrIndexVersionedTest.php
+++ b/tests/SolrIndexVersionedTest.php
@@ -137,6 +137,7 @@ class SolrVersionedTest_Index extends SolrIndex {
 	}
 }
 
+if (!class_exists('Phockito')) return;
 
 class SolrDocumentMatcher extends Hamcrest_BaseMatcher {
 	


### PR DESCRIPTION
If phockito isn't installed, the test case should fail gracefully with a skipped test notification, rather than a php class load error.
