### PR TITLE
Fix many_many fieldData bug

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -87,7 +87,7 @@ abstract class SearchIndex extends ViewableData {
 							);
 						}
 						else if ($manyMany = $singleton->many_many($lookup)) {
-							$class = $manyMany[0];
+							$class = $manyMany[1];
 							$options['multi_valued'] = true;
 							$options['lookup_chain'][] = array(
 								'call' => 'method', 'method' => $lookup,


### PR DESCRIPTION
This fixes a critical bug meaning that using many_many fields in full text searching would have always failed.

the $singleton->many_many() lookup returns an array() of many-many components, however the line $class = $manyMany[0] is wrong, as the first value of the array is always the $dataClass (parentClass), not the otherClass (childClass) (which is the second value).

Changing this to $class = $manyMany[1] fixes this bug.

Regards,
Daniel Pickering
