### PR TITLE
Added support for Translatable

### DIFF
--- a/conf/solr/4/extras/solrconfig.xml
+++ b/conf/solr/4/extras/solrconfig.xml
@@ -73,7 +73,8 @@
        with their external dependencies.
     -->
   <lib dir="./lib" />
-  
+
+  <!--
   <lib dir="../../../contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="../../../dist/" regex="solr-cell-\d.*\.jar" />
 
@@ -85,6 +86,9 @@
 
   <lib dir="../../../contrib/velocity/lib" regex=".*\.jar" />
   <lib dir="../../../dist/" regex="solr-velocity-\d.*\.jar" />
+  -->
+
+  <lib dir="/data/solr/lib/" regex=".*\.jar" />
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a 
        specific jar file.  This will cause a serious error to be logged 


### PR DESCRIPTION
Adds solr support for translatable (uses multiple cores).
Set the locale for each solr index (which extend SolrIndex) in config yml:

ChineseSiteSearchIndex:
  limitToLocale: zh_CN
SiteSearchIndex:
  limitToLocale: en_NZ

It will then append the correct locale to the cmd.

I also added the ability to quickly run a simple reindex on a particular index:
sake dev/tasks/Solr_Reindex index=ChineseSiteSearchIndex verbose=1


