### PR TITLE
BUGFIX Properly identify the foreign class in a many many relationship w...

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -87,7 +87,7 @@ abstract class SearchIndex extends ViewableData {
 							);
 						}
 						else if ($manyMany = $singleton->many_many($lookup)) {
-							$class = $manyMany[0];
+							$class = $manyMany[1];
 							$options['multi_valued'] = true;
 							$options['lookup_chain'][] = array(
 								'call' => 'method', 'method' => $lookup,


### PR DESCRIPTION
...hen building the schema

The first item in the array returned by DataObject#many_many is the parent class, not the foreign class, so we need to retrieve the second item of that list.
