### PR TITLE
Add a no-op query to prevent database timeouts during a long reindex

### DIFF
--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -270,6 +270,9 @@ class Solr_Reindex extends BuildTask {
 
 							// If we're in dev mode, commit more often for fun and profit
 							if (Director::isDev()) Solr::service($index)->commit();
+
+							// This will slow down things a tiny bit, but it is done so that we don't timeout to the database during a reindex
+							DB::query('SELECT 1');
 						}
 					}
 				}


### PR DESCRIPTION
Fix #56 

I am not sure if `SELECT 1` is the best option here, nor if it works for every database, so I would appreciate feedback/changes if possible.
