### PR TITLE
Use SolrIndex->getIndexName() consistently

### DIFF
--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -101,8 +101,9 @@ class Solr_Configure extends BuildTask {
 				$remote = isset($index['remotepath']) ? $index['remotepath'] : $local;
 				
 				foreach ($indexes as $index => $instance) {
+					$indexName = $instance->getIndexName();
 					$sourceDir = $instance->getExtrasPath();
-					$targetDir = "$local/$index/conf";
+					$targetDir = "$local/$indexName/conf";
 					if (!is_dir($targetDir)) {
 						$worked = @mkdir($targetDir, 0770, true);
 						if(!$worked) {
@@ -133,7 +134,8 @@ class Solr_Configure extends BuildTask {
 				$remote = $index['remotepath'];
 
 				foreach ($indexes as $index => $instance) {
-					$indexdir = "$url/$index";
+					$indexName = $instance->getIndexName();
+					$indexdir = "$url/$indexName";
 					if (!WebDAV::exists($indexdir)) WebDAV::mkdir($indexdir);
 
 					$sourceDir = $instance->getExtrasPath();
@@ -158,9 +160,9 @@ class Solr_Configure extends BuildTask {
 		foreach ($indexes as $index => $instance) {
 			$indexName = $instance->getIndexName();
 
-			if ($service->coreIsActive($index)) {
+			if ($service->coreIsActive($indexName)) {
 				echo "Reloading configuration...";
-				$service->coreReload($index);
+				$service->coreReload($indexName);
 				echo "done\n";
 			} else {
 				echo "Creating configuration...";
@@ -198,7 +200,8 @@ class Solr_Reindex extends BuildTask {
 			$class = get_class($this);
 
 			foreach (Solr::get_indexes() as $index => $instance) {
-				echo "Rebuilding {$instance->getIndexName()}\n\n";
+				$indexName = $instance->getIndexName();
+				echo "Rebuilding {$indexName}\n\n";
 
 				$classes = $instance->getClasses();
 				if($request->getVar('class')) {
@@ -206,7 +209,7 @@ class Solr_Reindex extends BuildTask {
 					$classes = array_intersect_key($classes, array_combine($limitClasses, $limitClasses));
 				}
 
-				Solr::service($index)->deleteByQuery('ClassHierarchy:(' . implode(' OR ', array_keys($classes)) . ')');
+				Solr::service($indexName)->deleteByQuery('ClassHierarchy:(' . implode(' OR ', array_keys($classes)) . ')');
 
 				foreach ($classes as $class => $options) {
 					$includeSubclasses = $options['include_children'];
@@ -240,12 +243,12 @@ class Solr_Reindex extends BuildTask {
 							if($verbose) echo "  ".preg_replace('/\r\n|\n/', '$0  ', $res)."\n";
 
 							// If we're in dev mode, commit more often for fun and profit
-							if (Director::isDev()) Solr::service($index)->commit();
+							if (Director::isDev()) Solr::service($indexName)->commit();
 						}
 					}
 				}
 
-				Solr::service($index)->commit();
+				Solr::service($indexName)->commit();
 			}
 		}
 


### PR DESCRIPTION
That's important in case we need to disambiguate the index, e.g. when multiple copies of the same codebase run on the same environment and server.
Example implementation:

function getIndexName() {
    return preg_replace('/[^\w]/i', '-', **FILE**);
}
