### PR TITLE
API Solr_Reindex uses configured SearchUpdater instead of always doing a direct write

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,3 +1,3 @@
 DataObject:
   extensions:
-    - 'SearchUpdater_DeleteHandler'
+    - 'SearchUpdater_ObjectHandler'

--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -163,7 +163,7 @@ class Solr_Configure extends BuildTask {
 		} else {
 			user_error('Unknown Solr index mode '.$indexstore['mode'], E_USER_ERROR);
 		}
-		
+
 		foreach ($indexes as $instance) {
 			$index = $instance->getIndexName();
 			echo "Configuring $index. \n"; flush();
@@ -200,7 +200,14 @@ class Solr_Configure extends BuildTask {
 
 
 class Solr_Reindex extends BuildTask {
-	static $recordsPerRequest = 200;
+
+	/**
+	 * Number of records to load and index per request
+	 *
+	 * @var int
+	 * @config
+	 */
+	private static $recordsPerRequest = 200;
 
 	public function run($request) {
 		increase_time_limit_to();
@@ -223,7 +230,7 @@ class Solr_Reindex extends BuildTask {
 
 			foreach (Solr::get_indexes() as $index => $instance) {
 				echo "Rebuilding {$instance->getIndexName()}\n\n";
-				
+
 				$classes = $instance->getClasses();
 				if($request->getVar('class')) {
 					$limitClasses = explode(',', $request->getVar('class'));
@@ -234,10 +241,10 @@ class Solr_Reindex extends BuildTask {
 
 				foreach ($classes as $class => $options) {
 					$includeSubclasses = $options['include_children'];
-					
+
 					foreach (SearchVariant::reindex_states($class, $includeSubclasses) as $state) {
 						if ($instance->variantStateExcluded($state)) continue;
-						
+
 						SearchVariant::activate_state($state);
 
 						$filter = $includeSubclasses ? "" : '"ClassName" = \''.$class."'";
@@ -259,12 +266,12 @@ class Solr_Reindex extends BuildTask {
 							echo "$offset..";
 
 							$cmd = "php $script dev/tasks/$self index=$index class=$class start=$offset variantstate=$statevar";
-							
+
 							if($verbose) {
 								echo "\n  Running '$cmd'\n";
-								$cmd .= " verbose=1";
+								$cmd .= " verbose=1 2>&1";
 							}
-							
+
 							$res = $verbose ? passthru($cmd) : `$cmd`;
 							if($verbose) echo "  ".preg_replace('/\r\n|\n/', '$0  ', $res)."\n";
 
@@ -304,9 +311,10 @@ class Solr_Reindex extends BuildTask {
 		foreach ($items as $item) {
 			if($verbose) echo $item->ID . ' ';
 
-			$index->add($item);
+			// See SearchUpdater_ObjectHandler::triggerReindex
+			$item->triggerReindex();
 
-			$item->destroy(); 
+			$item->destroy();
 		}
 
 		if($verbose) echo "Done ";


### PR DESCRIPTION
This should be amazing for people who like being able to trigger a reindex from the web, or those with lots of content they'd prefer that queuedjobs ran.

@hafriedlander please review that my doing exactly as you directed was the right solution. :)

I've done a few tests locally, both with the queuedjobs updater as well as the direct updater.