### PR TITLE
API Separate searchupdate / commit into separate queued-jobs

### DIFF
--- a/code/search/processors/SearchUpdateCommitJobProcessor.php
+++ b/code/search/processors/SearchUpdateCommitJobProcessor.php
@@ -1,0 +1,247 @@
+<?php
+
+if(!interface_exists('QueuedJob')) return;
+
+class SearchUpdateCommitJobProcessor implements QueuedJob {
+
+	/**
+	 * The QueuedJob queue to use when processing commits
+	 * 
+	 * @config
+	 * @var int
+	 */
+	private static $commit_queue = 2; // QueuedJob::QUEUED;
+
+	/**
+	 * List of indexes to commit
+	 *
+	 * @var array
+	 */
+	protected $indexes = array();
+
+	/**
+	 * True if this job is skipped to be be re-scheduled in the future
+	 *
+	 * @var boolean
+	 */
+	protected $skipped = false;
+
+	/**
+	 * List of completed indexes
+	 *
+	 * @var array
+	 */
+	protected $completed = array();
+
+	/**
+	 * List of messages
+	 *
+	 * @var array
+	 */
+	protected $messages = array();
+
+	/**
+	 * List of dirty indexes to be committed
+	 *
+	 * @var array
+	 */
+	public static $dirty_indexes = true;
+
+	/**
+	 * If solrindex::commit has already been performed, but additional commits are necessary,
+	 * how long do we wait before attempting to touch the index again?
+	 * 
+	 * {@see http://stackoverflow.com/questions/7512945/how-to-fix-exceeded-limit-of-maxwarmingsearchers}
+	 *
+	 * @var int
+	 * @config
+	 */
+	private static $cooldown = 300;
+
+	/**
+	 * True if any commits have been executed this request. If so, any attempts to run subsequent commits
+	 * should be delayed until next queuedjob to prevent solr reaching maxWarmingSearchers
+	 *
+	 * {@see http://stackoverflow.com/questions/7512945/how-to-fix-exceeded-limit-of-maxwarmingsearchers}
+	 *
+	 * @var boolean
+	 */
+	public static $has_run = false;
+
+	/**
+	 * This method is invoked once indexes with dirty ids have been updapted and a commit is necessary
+	 *
+	 * @param boolean $dirty Marks all indexes as dirty by default. Set to false if there are known comitted and
+	 * clean indexes
+	 * @param string $startAfter Start date
+	 * @return static The queued job
+	 */
+	public static function queue($dirty = true, $startAfter = null) {
+		$commit = Injector::inst()->create(__CLASS__);
+		singleton('QueuedJobService')->queueJob($commit, $startAfter);
+
+		if($dirty) {
+			$indexes = FullTextSearch::get_indexes();
+			static::$dirty_indexes = array_keys($indexes);
+		}
+		return $commit;
+	}
+
+	public function getJobType() {
+		return Config::inst()->get(__CLASS__, 'commit_queue');
+	}
+
+	public function getSignature() {
+		return md5(get_class($this) . time() . mt_rand(0, 100000));
+	}
+
+	public function getTitle() {
+		return "FullTextSearch Commit Job";
+	}
+
+	/**
+	 * Get the list of index names we should process
+	 *
+	 * @return array
+	 */
+	public function getAllIndexes() {
+		if(empty($this->indexes)) {
+			$indexes = FullTextSearch::get_indexes();
+			$this->indexes = array_keys($indexes);
+		}
+		return $this->indexes;
+	}
+
+	public function jobFinished() {
+		// If we've indexed exactly as many as we would like, we are done
+		return $this->skipped
+			|| (count($this->getAllIndexes()) <= count($this->completed));
+	}
+
+	public function prepareForRestart() {
+		// NOOP
+	}
+
+	public function afterComplete() {
+		// NOOP
+	}
+
+	/**
+	 * Abort this job, potentially rescheduling a replacement if there is still work to do
+	 */
+	protected function discardJob() {
+		$this->skipped = true;
+
+		// If we do not have dirty records, then assume that these dirty records were committed
+		// already this request (but probably another job), so we don't need to commit anything else.
+		// This could occur if we completed multiple searchupdate jobs in a prior request, and
+		// we only need one commit job to commit all of them in the current request.
+		if(empty(static::$dirty_indexes)) {
+			$this->addMessage("Indexing already completed this request: Discarding this job");
+			return;
+		}
+
+		
+		// If any commit has run, but some (or all) indexes are un-comitted, we must re-schedule this task.
+		// This could occur if we completed a searchupdate job in a prior request, as well as in
+		// the current request
+		$cooldown = Config::inst()->get(__CLASS__, 'cooldown');
+		$now = new DateTime(SS_Datetime::now()->getValue());
+		$now->add(new DateInterval('PT'.$cooldown.'S'));
+		$runat = $now->Format('Y-m-d H:i:s');
+
+		$this->addMessage("Indexing already run this request, but incomplete. Re-scheduling for {$runat}");
+
+		// Queue after the given cooldown
+		static::queue(false, $runat);
+	}
+
+	public function process() {
+		// If we have already run an instance of SearchUpdateCommitJobProcessor this request, immediately
+		// quit this job to prevent hitting warming search limits in Solr
+		if(static::$has_run) {
+			$this->discardJob();
+			return true;
+		}
+
+		// To prevent other commit jobs from running this request
+		static::$has_run = true;
+
+		// Run all incompleted indexes
+		$indexNames = $this->getAllIndexes();
+		foreach ($indexNames as $name) {
+			$index = singleton($name);
+			$this->commitIndex($index);
+		}
+
+		$this->addMessage("All indexes committed");
+
+		return true;
+	}
+
+	/**
+	 * Commits a specific index
+	 *
+	 * @param SolrIndex $index
+	 * @throws Exception
+	 */
+	protected function commitIndex($index) {
+		// Skip index if this is already complete
+		$name = get_class($index);
+		if(in_array($name, $this->completed)) {
+			$this->addMessage("Skipping already comitted index {$name}");
+			return;
+		}
+
+		// Bypass SolrIndex::commit exception handling so that queuedjobs can handle the error
+		$this->addMessage("Committing index {$name}");
+		$index->getService()->commit(false, false, false);
+		$this->addMessage("Committing index {$name} was successful");
+
+		// If this index is currently marked as dirty, it's now clean
+		if(in_array($name, static::$dirty_indexes)) {
+			static::$dirty_indexes = array_diff(static::$dirty_indexes, array($name));
+		}
+
+		// Mark complete
+		$this->completed[] = $name;
+	}
+
+	public function setup() {
+		// NOOP
+	}
+
+	public function getJobData() {
+		$data = new stdClass();
+		$data->totalSteps = count($this->getAllIndexes());
+		$data->currentStep = count($this->completed);
+		$data->isComplete = $this->jobFinished();
+		$data->messages = $this->messages;
+
+		$data->jobData = new stdClass();
+		$data->jobData->skipped = $this->skipped;
+		$data->jobData->completed = $this->completed;
+		$data->jobData->indexes = $this->getAllIndexes();
+
+		return $data;
+	}
+
+	public function setJobData($totalSteps, $currentStep, $isComplete, $jobData, $messages) {
+		$this->isComplete = $isComplete;
+		$this->messages = $messages;
+
+		$this->skipped = $jobData->skipped;
+		$this->completed = $jobData->completed;
+		$this->indexes = $jobData->indexes;
+	}
+
+	public function addMessage($message, $severity='INFO') {
+		$severity = strtoupper($severity);
+		$this->messages[] = '[' . date('Y-m-d H:i:s') . "][$severity] $message";
+	}
+
+	public function getMessages() {
+		return $this->messages;
+	}
+
+}

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -121,6 +121,32 @@ As you can only search one index at a time, all searchable classes need to be in
 		}
 	}
 
+## Using Multiple Indexes
+
+Multiple indexes can be created and searched independently, but if you wish to override an existing
+index with another, you can use the `$hide_ancestor` config.
+
+	:::php
+	class MyReplacementIndex extends MyIndex {
+		private static $hide_ancestor = 'MyIndex';
+
+		public function init() {
+			parent::init();
+			$this->addClass('File');
+			$this->addFulltextField('Title');
+		}
+	}
+
+You can also filter all indexes globally to a set of pre-defined classes if you wish to 
+prevent any unknown indexes from being automatically included.
+
+	:::yaml
+	FullTextSearch:
+	  indexes:
+	    - MyReplacementIndex
+	    - CoreSearchIndex
+
+
 ## Indexing Relationships
 
 TODO

--- a/tests/BatchedProcessorTest.php
+++ b/tests/BatchedProcessorTest.php
@@ -14,6 +14,21 @@ class BatchedProcessorTest_Index extends SearchIndex_Recording implements TestOn
 	}
 }
 
+class BatchedProcessor_QueuedJobService {
+	protected $jobs = array();
+
+	public function queueJob(QueuedJob $job, $startAfter = null, $userId = null, $queueName = null) {
+		$this->jobs[] = array(
+			'job' => $job,
+			'startAfter' => $startAfter
+		);
+	}
+
+	public function getJobs() {
+		return $this->jobs;
+	}
+}
+
 /**
  * Tests {@see SearchUpdateQueuedJobProcessor}
  */
@@ -25,6 +40,13 @@ class BatchedProcessorTest extends SapphireTest {
 		'BatchedProcessorTest_Object'
 	);
 
+	protected $illegalExtensions = array(
+		'SiteTree' => array(
+			'SiteTreeSubsites',
+			'Translatable'
+		)
+	);
+
 	public function setUp() {
 		parent::setUp();
 		Config::nest();
@@ -33,11 +55,22 @@ class BatchedProcessorTest extends SapphireTest {
 			$this->markTestSkipped("These tests need the QueuedJobs module installed to run");
 			$this->skipTest = true;
 		}
+
+
+		SS_Datetime::set_mock_now('2015-05-07 06:00:00');
 		
 		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_size', 5);
 		Config::inst()->update('SearchUpdateBatchedProcessor', 'batch_soft_cap', 0);
+		Config::inst()->update('SearchUpdateCommitJobProcessor', 'cooldown', 600);
 		
 		Versioned::reading_stage("Stage");
+
+		Injector::inst()->registerService(new BatchedProcessor_QueuedJobService(), 'QueuedJobService');
+
+		FullTextSearch::force_index_list('BatchedProcessorTest_Index');
+
+		SearchUpdateCommitJobProcessor::$dirty_indexes = array();
+		SearchUpdateCommitJobProcessor::$has_run = false;
 		
 		$this->oldProcessor = SearchUpdater::$processor;
 		SearchUpdater::$processor = new SearchUpdateQueuedJobProcessor();
@@ -47,9 +80,14 @@ class BatchedProcessorTest extends SapphireTest {
 		
 		SearchUpdater::$processor = $this->oldProcessor;
 		Config::unnest();
+		Injector::inst()->unregisterNamedObject('QueuedJobService');
+		FullTextSearch::force_index_list();
 		parent::tearDown();
 	}
-	
+
+	/**
+	 * @return SearchUpdateQueuedJobProcessor
+	 */
 	protected function generateDirtyIds() {
 		$processor = SearchUpdater::$processor;
 		for($id = 1; $id <= 42; $id++) {
@@ -100,7 +138,60 @@ class BatchedProcessorTest extends SapphireTest {
 		$this->assertEquals(9, $data->currentStep);
 		$this->assertEquals(42, count($index->getAdded()));
 		$this->assertTrue($data->isComplete);
+
+		// Check any additional queued jobs
+		$processor->afterComplete();
+		$service = singleton('QueuedJobService');
+		$jobs = $service->getJobs();
+		$this->assertEquals(1, count($jobs));
+		$this->assertInstanceOf('SearchUpdateCommitJobProcessor', $jobs[0]['job']);
 	}
+
+	/**
+	 * Test creation of multiple commit jobs
+	 */
+	public function testMultipleCommits() {
+		$index = singleton('BatchedProcessorTest_Index');
+		$index->reset();
+
+		// Test that running a commit immediately after submitting to the indexes
+		// correctly commits
+		$first = SearchUpdateCommitJobProcessor::queue();
+		$second = SearchUpdateCommitJobProcessor::queue();
+
+		$this->assertFalse($index->getIsCommitted());
+
+		// First process will cause the commit
+		$this->assertFalse($first->jobFinished());
+		$first->process();
+		$allMessages = $first->getMessages();
+		$this->assertTrue($index->getIsCommitted());
+		$this->assertTrue($first->jobFinished());
+		$this->assertStringEndsWith('All indexes committed', $allMessages[2]);
+
+		// Executing the subsequent processor should not re-trigger a commit
+		$index->reset();
+		$this->assertFalse($second->jobFinished());
+		$second->process();
+		$allMessages = $second->getMessages();
+		$this->assertFalse($index->getIsCommitted());
+		$this->assertTrue($second->jobFinished());
+		$this->assertStringEndsWith('Indexing already completed this request: Discarding this job', $allMessages[0]);
+
+		// Given that a third job is created, and the indexes are dirtied, attempting to run this job
+		// should result in a delay
+		$index->reset();
+		$third = SearchUpdateCommitJobProcessor::queue();
+		$this->assertFalse($third->jobFinished());
+		$third->process();
+		$this->assertTrue($third->jobFinished());
+		$allMessages = $third->getMessages();
+		$this->assertStringEndsWith(
+			'Indexing already run this request, but incomplete. Re-scheduling for 2015-05-07 06:10:00',
+			$allMessages[0]
+		);
+	}
+
 	
 	/**
 	 * Tests that the batch_soft_cap setting is properly respected

--- a/tests/BatchedProcessorTest.php
+++ b/tests/BatchedProcessorTest.php
@@ -22,6 +22,7 @@ class BatchedProcessor_QueuedJobService {
 			'job' => $job,
 			'startAfter' => $startAfter
 		);
+		return $job;
 	}
 
 	public function getJobs() {


### PR DESCRIPTION
Oh my good, look at this pull request. It's so amazing!

What have I done! On a coffee-less afternoon nonetheless?

- Indexes can finally hide other indexes. This is useful when you don't want classes to be indexed, but they could be in a third party module you don't want to edit. (see docs below) This in itself is a great performance increase, but no longer do you need to have solr indexing work done on indexes you don't want to maintain.

- SolrIndex::commit has been split into a separate queued job which is added to the queue once an update job has been completed. This is useful if you want to run multiple update jobs in a sequence, but don't want to run into the dreaded `exceeded limit of maxWarmingSearchers=X` error.

It also nicely bunches several smaller updates into a single commit, so hopefully less work is done overall.

Also if for whatever reason a commit is made in a single job, and updates occur later (again, requiring further updates) then the job will be re-added to the queue with a nice cooldown (defaults to 10 minutes) to prevent solr erroring, and giving time for the rest of the job queue to complete.