### PR TITLE
Regression in SearchUpdater_ObjectHandler

### DIFF
--- a/code/search/SearchUpdater.php
+++ b/code/search/SearchUpdater.php
@@ -222,7 +222,7 @@ class SearchUpdater_ObjectHandler extends DataExtension {
 
 		$id = $this->owner->ID;
 		$class = $this->owner->ClassName;
-		$state = SearchVariant::current_state();
+		$state = SearchVariant::current_state($class);
 		$base = ClassInfo::baseDataClass($class);
 		$key = "$id:$base:".serialize($state);
 


### PR DESCRIPTION
Stopped indexing of classes which were unrelated to overall variants.
For example, an index with excludeVariantState(array('SearchVariantVersioned' => 'Stage'))
should only set this variant state on types where appliesTo() returns true, namely "Page".
Without the $class parameter it also returned on "File" index requests,
which then lead to all index requests being discarded later on somewhere in SearchUpdater.

Regression introduced in 625d282.

cc @tractorcow 