### PR TITLE
API Support custom files / spelling correction

### DIFF
--- a/conf/solr/4/extras/solrconfig.xml
+++ b/conf/solr/4/extras/solrconfig.xml
@@ -863,6 +863,10 @@
          <str>nameOfCustomComponent2</str>
        </arr>
       -->
+	  	  
+      <arr name="last-components">
+        <str>spellcheck</str>
+      </arr>
     </requestHandler>
 
   <!-- A request handler that returns indented JSON by default -->
@@ -1254,7 +1258,31 @@
     <!-- a spellchecker built from a field of the main index -->
     <lst name="spellchecker">
       <str name="name">default</str>
-      <str name="field">text</str>
+      <str name="field">_text</str>
+      <str name="classname">solr.DirectSolrSpellChecker</str>
+      <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
+      <str name="distanceMeasure">internal</str>
+      <!-- minimum accuracy needed to be considered a valid spellcheck suggestion -->
+      <float name="accuracy">0.5</float>
+      <!-- the maximum #edits we consider when enumerating terms: can be 1 or 2 -->
+      <int name="maxEdits">2</int>
+      <!-- the minimum shared prefix when enumerating terms -->
+      <int name="minPrefix">1</int>
+      <!-- maximum number of inspections per result. -->
+      <int name="maxInspections">5</int>
+      <!-- minimum length of a query term to be considered for correction -->
+      <int name="minQueryLength">4</int>
+      <!-- maximum threshold of documents a query term can appear to be considered for correction -->
+      <float name="maxQueryFrequency">0.01</float>
+      <!-- uncomment this to require suggestions to occur in 1% of the documents
+      	<float name="thresholdTokenFrequency">.01</float>
+      -->
+    </lst>
+
+	<!-- Custom spellcheck dictionary limited to an optional _spellcheckText field -->
+    <lst name="spellchecker">
+      <str name="name">_spellcheck</str>
+      <str name="field">_spellcheckText</str>
       <str name="classname">solr.DirectSolrSpellChecker</str>
       <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
       <str name="distanceMeasure">internal</str>
@@ -1279,7 +1307,7 @@
     <lst name="spellchecker">
       <str name="name">wordbreak</str>
       <str name="classname">solr.WordBreakSolrSpellChecker</str>      
-      <str name="field">name</str>
+      <str name="field">_text</str>
       <str name="combineWords">true</str>
       <str name="breakWords">true</str>
       <int name="maxChanges">10</int>


### PR DESCRIPTION
Default config has been fixed (previously would crash on references to name and text fields, when we should use the _text field consistently).

uploadConfig has been refactored out of Solr_Configure into SolrIndex, so that specific indexes can have control over additional files (e.g. synonyms.txt) that are necessary.

Issues with parsing of collation results from solr have been resolved. If the collation result is an object, the suggestions are parsed in turn until a suggestion is returned.