### PR TITLE
API Enable boosted fields to be specified on the index

### DIFF
--- a/conf/solr/4/templates/schema.ss
+++ b/conf/solr/4/templates/schema.ss
@@ -61,7 +61,7 @@
 
 	<uniqueKey>_documentid</uniqueKey>
 
-	<defaultSearchField>_text</defaultSearchField>
+	<defaultSearchField>$DefaultField</defaultSearchField>
 
 	<solrQueryParser defaultOperator="OR"/>
 

--- a/docs/en/Solr.md
+++ b/docs/en/Solr.md
@@ -224,7 +224,11 @@ These fields are defined in the schema.xml file that gets sent to Solr.
 	// the request to Solr would be:
 	// q=(SiteTree_Title:Lorem+OR+SiteTree_Content:Lorem)
 
-### Configuring boosts on fields
+### Configuring boosts
+
+There are several ways in which you can configure boosting on search fields or terms.
+
+#### Boosting on search query
 
 Solr has a way of specifying which fields should be boosted as a parameter to `SearchQuery`.
 
@@ -243,6 +247,35 @@ In this example, we enter "Lorem" as the search term, and boost the `Content` fi
 	// q=SiteTree_Content:Lorem^2
 
 More information on [relevancy on the Solr wiki](http://wiki.apache.org/solr/SolrRelevancyFAQ).
+
+### Boosting on index fields
+
+Boost values for specific can also be specified directly on the `SolrIndex` class directly.
+
+The following methods can be used to set one or more boosted fields:
+
+* `SolrIndex::addBoostedField` Adds a field with a specific boosted value (defaults to 2)
+* `SolrIndex::setFieldBoosting` If a field has already been added to an index, the boosting
+  value can be customised, changed, or reset for a single field.
+* `SolrIndex::addFulltextField` A boost can be set for a field using the `$extraOptions` parameter
+with the key `boost` assigned to the desired value.
+
+For example:
+
+
+	:::php
+	class SolrSearchIndex extends SolrIndex {
+
+		public function init() {
+			$this->addClass('SiteTree');
+			$this->addAllFulltextFields();
+			$this->addFilterField('ShowInSearch');
+			this->addBoostedField('Title', null, array(), 1.5);
+			this->setFieldBoosting('SiteTree_SearchBoost', 2);
+		}
+
+	}
+
 
 ### Custom Types
 

--- a/tests/SearchVariantVersionedTest.php
+++ b/tests/SearchVariantVersionedTest.php
@@ -1,30 +1,12 @@
 <?php
 
-class SearchVariantVersionedTest_Item extends SiteTree {
-	// TODO: Currently theres a failure if you addClass a non-table class
-	private static $db = array(
-		'TestText' => 'Varchar'
-	);
-}
-
-class SearchVariantVersionedTest_Index extends SearchIndex_Recording {
-	function init() {
-		$this->addClass('SearchVariantVersionedTest_Item');
-		$this->addFilterField('TestText');
-	}
-}
-
-class SearchVariantVersionedTest_IndexNoStage extends SearchIndex_Recording {
-	function init() {
-		$this->addClass('SearchVariantVersionedTest_Item');
-		$this->addFilterField('TestText');
-		$this->excludeVariantState(array('SearchVariantVersioned' => 'Stage'));
-	}
-}
-
 class SearchVariantVersionedTest extends SapphireTest {
 
 	private static $index = null;
+
+	protected $extraDataObjects = array(
+		'SearchVariantVersionedTest_Item'
+	);
 
 	function setUp() {
 		parent::setUp();
@@ -106,5 +88,27 @@ class SearchVariantVersionedTest extends SapphireTest {
 		$this->assertEquals($index->getAdded(array('ID', '_versionedstage')), array(
 			array('ID' => $item->ID, '_versionedstage' => 'Live')
 		));
+	}
+}
+
+class SearchVariantVersionedTest_Item extends SiteTree implements TestOnly {
+	// TODO: Currently theres a failure if you addClass a non-table class
+	private static $db = array(
+		'TestText' => 'Varchar'
+	);
+}
+
+class SearchVariantVersionedTest_Index extends SearchIndex_Recording {
+	function init() {
+		$this->addClass('SearchVariantVersionedTest_Item');
+		$this->addFilterField('TestText');
+	}
+}
+
+class SearchVariantVersionedTest_IndexNoStage extends SearchIndex_Recording {
+	function init() {
+		$this->addClass('SearchVariantVersionedTest_Item');
+		$this->addFilterField('TestText');
+		$this->excludeVariantState(array('SearchVariantVersioned' => 'Stage'));
 	}
 }


### PR DESCRIPTION
Although you can already specify boosting (with some effort) at the time of query, it can be a lot more convenient to specify specific boosts on individual fields when declaring your index schema.

Includes tests and documentation!

Note that `$extra_options['boost']` actually crashes solr, so although we give a consistent interface, we actually need to intercept that custom option internally.