### PR TITLE
API Additional support for custom copy_fields

### DIFF
--- a/conf/solr/4/templates/types.ss
+++ b/conf/solr/4/templates/types.ss
@@ -203,6 +203,17 @@
         </analyzer>
     </fieldType>
 
+    <!-- Text optimized for spelling corrections, with minimal alterations (e.g. no stemming) but also html filtering -->
+    <fieldType name="textSpellHtml" class="solr.TextField" positionIncrementGap="100">
+        <analyzer>
+            <charFilter class="solr.HTMLStripCharFilterFactory"/>
+            <tokenizer class="solr.StandardTokenizerFactory" />
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
+            <filter class="solr.LengthFilterFactory" min="4" max="20" />
+            <filter class="solr.LowerCaseFilterFactory" /> 
+            <filter class="solr.RemoveDuplicatesTokenFilterFactory" /> 
+        </analyzer>
+    </fieldType>
 
     <!-- A general unstemmed text field - good if one does not know the language of the field -->
     <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">

--- a/docs/en/Solr.md
+++ b/docs/en/Solr.md
@@ -183,7 +183,7 @@ This can be fixed by aggregating spell checking data in a separate
 			$xml = parent::getFieldDefinitions();
 			
 			$xml .= "\n\n\t\t<!-- Additional custom fields for spell checking -->";
-			$xml .= "\n\t\t<field name='spellcheckData' type='textSpell' indexed='true' stored='false' multiValued='true' />";
+			$xml .= "\n\t\t<field name='spellcheckData' type='textSpellHtml' indexed='true' stored='false' multiValued='true' />";
 
 			return $xml;
 		}


### PR DESCRIPTION
This means that if we want to copy all fields to another, we can do it in one place, rather than having an explicit copy for each additional source / destination pair.

Also adds additional textSpellHtml type for html-safe spelling database generation. The default spellcheck field didn't do HTML cleaning so wasn't very safe.