### PR TITLE
MINOR: Don't include Hamcrest globally so it doesn't conflict with PHPUnit

### DIFF
--- a/tests/SolrReindexTest.php
+++ b/tests/SolrReindexTest.php
@@ -5,7 +5,7 @@ use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 
-if (class_exists('Phockito')) Phockito::include_hamcrest();
+if (class_exists('Phockito')) Phockito::include_hamcrest(false);
 
 class SolrReindexTest extends SapphireTest {
 
@@ -251,7 +251,7 @@ class SolrReindexTest extends SapphireTest {
 
 		// Check ids
 		$this->assertEquals(120, count($ids));
-		Phockito::verify($this->service, 6)->deleteByQuery(anything());
+		Phockito::verify($this->service, 6)->deleteByQuery(\Hamcrest_Matchers::anything());
 		Phockito::verify($this->service, 1)->deleteByQuery(
 			'+(ClassHierarchy:SolrReindexTest_Item) +_query_:"{!frange l=0 u=0}mod(ID, 6)" +(_testvariant:"1")'
 		);


### PR DESCRIPTION
PHPUnit now includes matching functions like `any()` and `anything()` outside of a namespace, which conflicts with Phockito that does the same thing when calling `Phockito::include_hamcrest(true)`.

This test in particular breaks Behat, because the file includes a class (`SolrReindexTest_Item`) that extends `DataObject`, meaning that this file gets included very early in the initialisation process.

Instead, we can just set `Phockito::include_hamcrest(false)` and use the full path to the Hamcrest matching functions instead (e.g. `\Hamcrest_Matchers::anything()`).