### PR TITLE
adding ability for solr suffix and prefixing

### DIFF
--- a/code/solr/SolrIndex.php
+++ b/code/solr/SolrIndex.php
@@ -80,9 +80,25 @@ abstract class SolrIndex extends SearchIndex
         return $this->renderWith($this->getTemplatesPath() . '/schema.ss');
     }
 
+    /**
+     * Helper for returning the correct index name. Supports prefixing and
+     * suffixing
+     *
+     * @return string
+     */
     public function getIndexName()
     {
-        return get_class($this);
+        $name = get_class($this);
+
+        if(defined('SS_SOLR_INDEX_PREFIX')) {
+            $name = SS_SOLR_INDEX_PREFIX . ''. $name;
+        }
+
+        if(defined('SS_SOLR_INDEX_SUFFIX')) {
+            $name = $name . '' . SS_SOLR_INDEX_SUFFIX;
+        }
+
+        return $name;
     }
 
     public function getTypes()

--- a/code/solr/reindex/handlers/SolrReindexImmediateHandler.php
+++ b/code/solr/reindex/handlers/SolrReindexImmediateHandler.php
@@ -52,9 +52,10 @@ class SolrReindexImmediateHandler extends SolrReindexBase
 
         // Build script
         $indexName = $indexInstance->getIndexName();
+        $indexClass = get_class($indexInstance);
         $scriptPath = sprintf("%s%sframework%scli-script.php", BASE_PATH, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
         $scriptTask = "php {$scriptPath} dev/tasks/{$taskName}";
-        $cmd = "{$scriptTask} index={$indexName} class={$class} group={$group} groups={$groups} variantstate={$statevar}";
+        $cmd = "{$scriptTask} index={$indexClass} class={$class} group={$group} groups={$groups} variantstate={$statevar}";
         $cmd .= " verbose=1 2>&1";
         $logger->info("Running '$cmd'");
 
@@ -66,7 +67,7 @@ class SolrReindexImmediateHandler extends SolrReindexBase
 
         // If we're in dev mode, commit more often for fun and profit
         if (Director::isDev()) {
-            Solr::service(get_class($indexInstance))->commit();
+            Solr::service($indexClass)->commit();
         }
 
         // This will slow down things a tiny bit, but it is done so that we don't timeout to the database during a reindex

--- a/code/solr/reindex/handlers/SolrReindexQueuedHandler.php
+++ b/code/solr/reindex/handlers/SolrReindexQueuedHandler.php
@@ -75,7 +75,7 @@ class SolrReindexQueuedHandler extends SolrReindexBase
         // Trigger another job for this group
         $job = Injector::inst()->create(
             'SolrReindexGroupQueuedJob',
-            $indexInstance->getIndexName(), $state, $class, $groups, $group
+            get_class($indexInstance), $state, $class, $groups, $group
         );
         $this
             ->getQueuedJobService()


### PR DESCRIPTION
This means the same code can run on a single solr core and have the same indexes but use prefixes or suffixes to keep them separate