### PR TITLE
MINOR: Don't include Hamcrest globally so it doesn't conflict with PHPUnit

### DIFF
--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -6,7 +6,7 @@ class SolrIndexTest extends SapphireTest
         parent::setUpOnce();
 
         if (class_exists('Phockito')) {
-            Phockito::include_hamcrest();
+            Phockito::include_hamcrest(false);
         }
     }
 
@@ -59,7 +59,14 @@ class SolrIndexTest extends SapphireTest
     public function testBoostedQuery()
     {
         $serviceMock = $this->getServiceMock();
-        Phockito::when($serviceMock)->search(anything(), anything(), anything(), anything(), anything())->return($this->getFakeRawSolrResponse());
+        Phockito::when($serviceMock)
+            ->search(
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything()
+            )->return($this->getFakeRawSolrResponse());
 
         $index = new SolrIndexTest_FakeIndex();
         $index->setService($serviceMock);
@@ -72,7 +79,14 @@ class SolrIndexTest extends SapphireTest
         );
         $index->search($query);
 
-        Phockito::verify($serviceMock)->search('+(Field1:term^1.5 OR HasOneObject_Field1:term^3)', anything(), anything(), anything(), anything());
+        Phockito::verify($serviceMock)
+            ->search(
+                '+(Field1:term^1.5 OR HasOneObject_Field1:term^3)',
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything()
+            );
     }
     
     /**
@@ -82,8 +96,13 @@ class SolrIndexTest extends SapphireTest
     {
         $serviceMock = $this->getServiceMock();
         Phockito::when($serviceMock)
-            ->search(anything(), anything(), anything(), anything(), anything())
-            ->return($this->getFakeRawSolrResponse());
+            ->search(
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything(),
+                \Hamcrest_Matchers::anything()
+            )->return($this->getFakeRawSolrResponse());
 
         $index = new SolrIndexTest_BoostedIndex();
         $index->setService($serviceMock);
@@ -98,13 +117,25 @@ class SolrIndexTest extends SapphireTest
             new Hamcrest_Core_IsEqual('SearchUpdaterTest_Container_Field1^1.5 SearchUpdaterTest_Container_Field2^2.1 _text')
         );
         Phockito::verify($serviceMock)
-            ->search('+term', anything(), anything(), $matcher, anything());
+            ->search(
+                '+term',
+                \Hamcrest_Matchers::anything(),
+				\Hamcrest_Matchers::anything(),
+                $matcher,
+				\Hamcrest_Matchers::anything()
+            );
     }
 
     public function testHighlightQueryOnBoost()
     {
         $serviceMock = $this->getServiceMock();
-        Phockito::when($serviceMock)->search(anything(), anything(), anything(), anything(), anything())->return($this->getFakeRawSolrResponse());
+        Phockito::when($serviceMock)->search(
+            \Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::anything()
+		)->return($this->getFakeRawSolrResponse());
 
         $index = new SolrIndexTest_FakeIndex();
         $index->setService($serviceMock);
@@ -120,10 +151,10 @@ class SolrIndexTest extends SapphireTest
         Phockito::verify(
             $serviceMock)->search(
             '+(Field1:term^1.5 OR HasOneObject_Field1:term^3)',
-            anything(),
-            anything(),
-            not(hasKeyInArray('hl.q')),
-            anything()
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::not(\Hamcrest_Matchers::hasKeyInArray('hl.q')),
+			\Hamcrest_Matchers::anything()
         );
 
         // Search with highlighting
@@ -137,10 +168,10 @@ class SolrIndexTest extends SapphireTest
         Phockito::verify(
             $serviceMock)->search(
             '+(Field1:term^1.5 OR HasOneObject_Field1:term^3)',
-            anything(),
-            anything(),
-            hasKeyInArray('hl.q'),
-            anything()
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::anything(),
+			\Hamcrest_Matchers::hasKeyInArray('hl.q'),
+			\Hamcrest_Matchers::anything()
         );
     }
 

--- a/tests/SolrIndexVersionedTest.php
+++ b/tests/SolrIndexVersionedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 if (class_exists('Phockito')) {
-    Phockito::include_hamcrest();
+    Phockito::include_hamcrest(false);
 }
 
 class SolrIndexVersionedTest extends SapphireTest

--- a/tests/SolrReindexQueuedTest.php
+++ b/tests/SolrReindexQueuedTest.php
@@ -146,7 +146,7 @@ class SolrReindexQueuedTest extends SapphireTest
         // Deletes are performed in the main task prior to individual groups being processed
         // 18 records means 3 groups of 6 in each variant (6 total)
         Phockito::verify($this->service, 2)
-            ->deleteByQuery(anything());
+            ->deleteByQuery(\Hamcrest_Matchers::anything());
         $this->assertEquals(1, $logger->countMessages('Beginning init of reindex'));
         $this->assertEquals(6, $logger->countMessages('Queued Solr Reindex Group '));
         $this->assertEquals(3, $logger->countMessages(' of SolrReindexTest_Item in {"SolrReindexTest_Variant":"0"}'));

--- a/tests/SolrReindexTest.php
+++ b/tests/SolrReindexTest.php
@@ -6,7 +6,7 @@ use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 
 if (class_exists('Phockito')) {
-    Phockito::include_hamcrest();
+    Phockito::include_hamcrest(false);
 }
 
 class SolrReindexTest extends SapphireTest
@@ -262,7 +262,7 @@ class SolrReindexTest extends SapphireTest
 
         // Check ids
         $this->assertEquals(120, count($ids));
-        Phockito::verify($this->service, 6)->deleteByQuery(anything());
+        Phockito::verify($this->service, 6)->deleteByQuery(\Hamcrest_Matchers::anything());
         Phockito::verify($this->service, 1)->deleteByQuery(
             '+(ClassHierarchy:SolrReindexTest_Item) +_query_:"{!frange l=0 u=0}mod(ID, 6)" +(_testvariant:"1")'
         );


### PR DESCRIPTION
PHPUnit now includes matching functions like `any()` and `anything()` outside of a namespace, which conflicts with `Phockito` that does the same thing when calling `Phockito::include_hamcrest(true)`.

This test in particular breaks Behat, because the file includes a class (`SolrReindexTest_Item`) that extends `DataObject`, meaning that this file gets included very early in the initialisation process.

Instead, we can just set `Phockito::include_hamcrest(false)` and use the full path to the Hamcrest matching functions instead (e.g. `\Hamcrest_Matchers::anything()`).