### PR TITLE
FIX Indexes with custom index names that dont match the classname wer…

### DIFF
--- a/code/solr/reindex/handlers/SolrReindexImmediateHandler.php
+++ b/code/solr/reindex/handlers/SolrReindexImmediateHandler.php
@@ -66,7 +66,7 @@ class SolrReindexImmediateHandler extends SolrReindexBase
 
         // If we're in dev mode, commit more often for fun and profit
         if (Director::isDev()) {
-            Solr::service($indexName)->commit();
+            Solr::service(get_class($indexInstance))->commit();
         }
 
         // This will slow down things a tiny bit, but it is done so that we don't timeout to the database during a reindex


### PR DESCRIPTION
…e breaking

---

At the moment if you define an index like so:

```php

class MyIndex extends SolrIndex {

    public function init() {
        ...
    }

    public function getIndexName() {
        return "some-string";
    }

}
````

Then on Reindex task the following error is output:

```
ERROR [User Error]: Uncaught ReflectionException: Class some-string does not exist
IN GET /dev/tasks/Solr_Reindex
Line 14 in /vagrant/www/car.local/public_html/framework/control/injector/InjectionCreator.php
```

This patch fixes that by searching for the SolrIndex by IndexName if the name does not exist as a class.