### PR TITLE
BUGFIX: Fixed issue where the $id variable would be overridden in derived fields

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -552,8 +552,8 @@ abstract class SearchIndex extends ViewableData
                         $dirty[$base] = array();
                     }
 
-                    foreach ($ids as $id) {
-                        $statefulid = array('id' => $id, 'state' => $state);
+                    foreach ($ids as $rid) {
+                        $statefulid = array('id' => $rid, 'state' => $state);
                         $key = serialize($statefulid);
                         $dirty[$base][$key] = $statefulid;
                     }


### PR DESCRIPTION
When using derived fields subsequent iterations of the loop on [line 527](https://github.com/silverstripe-labs/silverstripe-fulltextsearch/blob/master/code/search/SearchIndex.php#L527) can in some cases be reset to an id that is not the one being re-indexed resulting in a SQL error.