### PR TITLE
BUG Fix versioned writes where subtables have no fields key

### DIFF
--- a/code/search/SearchUpdater.php
+++ b/code/search/SearchUpdater.php
@@ -90,14 +90,14 @@ class SearchUpdater extends Object
         $writes = array();
 
         foreach ($manipulation as $table => $details) {
-            if (!isset($details['id']) || !isset($details['fields'])) {
+            if (!isset($details['id'])) {
                 continue;
             }
 
             $id = $details['id'];
             $state = $details['state'];
             $class = $details['class'];
-            $fields = $details['fields'];
+            $fields = isset($details['fields']) ? $details['fields'] : array();
 
             $base = ClassInfo::baseDataClass($class);
             $key = "$id:$base:".serialize($state);
@@ -125,6 +125,13 @@ class SearchUpdater extends Object
             }
         }
 
+        // Trim records without fields
+        foreach(array_keys($writes) as $key) {
+            if(empty($writes[$key]['fields'])) {
+                unset($writes[$key]);
+            }
+        }
+
         // Then extract any state that is needed for the writes
 
         SearchVariant::call('extractManipulationWriteState', $writes);
@@ -136,7 +143,7 @@ class SearchUpdater extends Object
 
     /**
      * Send updates to the current search processor for execution
-     * 
+     *
      * @param array $writes
      */
     public static function process_writes($writes)

--- a/tests/SearchUpdaterTest.php
+++ b/tests/SearchUpdaterTest.php
@@ -74,7 +74,7 @@ class SearchUpdaterTest extends SapphireTest
     protected $usesDatabase = true;
 
     private static $index = null;
-    
+
     public function setUp()
     {
         parent::setUp();
@@ -87,21 +87,12 @@ class SearchUpdaterTest extends SapphireTest
 
         SearchUpdater::bind_manipulation_capture();
 
-        Config::nest();
-
         Config::inst()->update('Injector', 'SearchUpdateProcessor', array(
             'class' => 'SearchUpdateImmediateProcessor'
         ));
 
         FullTextSearch::force_index_list(self::$index);
         SearchUpdater::clear_dirty_indexes();
-    }
-
-    public function tearDown()
-    {
-        Config::unnest();
-
-        parent::tearDown();
     }
 
     public function testBasic()

--- a/tests/SearchVariantVersionedTest.php
+++ b/tests/SearchVariantVersionedTest.php
@@ -2,6 +2,9 @@
 
 class SearchVariantVersionedTest extends SapphireTest
 {
+    /**
+     * @var SearchVariantVersionedTest_Index
+     */
     private static $index = null;
 
     protected $extraDataObjects = array(
@@ -23,21 +26,12 @@ class SearchVariantVersionedTest extends SapphireTest
 
         SearchUpdater::bind_manipulation_capture();
 
-        Config::nest();
-
         Config::inst()->update('Injector', 'SearchUpdateProcessor', array(
             'class' => 'SearchUpdateImmediateProcessor'
         ));
 
         FullTextSearch::force_index_list(self::$index);
         SearchUpdater::clear_dirty_indexes();
-    }
-
-    public function tearDown()
-    {
-        Config::unnest();
-
-        parent::tearDown();
     }
 
     public function testPublishing()
@@ -71,9 +65,13 @@ class SearchVariantVersionedTest extends SapphireTest
         $item->write();
 
         SearchUpdater::flush_dirty_indexes();
-        $this->assertEquals(self::$index->getAdded(array('ID', '_versionedstage')), array(
-            array('ID' => $item->ID, '_versionedstage' => 'Stage')
+
+        $expected = array(array(
+            'ID' => $item->ID,
+            '_versionedstage' => 'Stage'
         ));
+        $added = self::$index->getAdded(array('ID', '_versionedstage'));
+        $this->assertEquals($expected, $added);
     }
 
     public function testExcludeVariantState()

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -12,12 +12,12 @@ class SolrIndexTest extends SapphireTest
 
     public function setUp()
     {
+        parent::setUp();
+
         if (!class_exists('Phockito')) {
             $this->markTestSkipped("These tests need the Phockito module installed to run");
             $this->skipTest = true;
         }
-
-        parent::setUp();
     }
 
     public function testFieldDataHasOne()
@@ -88,7 +88,7 @@ class SolrIndexTest extends SapphireTest
                 \Hamcrest_Matchers::anything()
             );
     }
-    
+
     /**
      * Test boosting on field schema (via queried fields parameter)
      */

--- a/tests/SolrIndexVersionedTest.php
+++ b/tests/SolrIndexVersionedTest.php
@@ -7,9 +7,9 @@ if (class_exists('Phockito')) {
 class SolrIndexVersionedTest extends SapphireTest
 {
     protected $oldMode = null;
-    
+
     protected static $index = null;
-    
+
     protected $extraDataObjects = array(
         'SearchVariantVersionedTest_Item'
     );
@@ -17,7 +17,7 @@ class SolrIndexVersionedTest extends SapphireTest
     public function setUp()
     {
         parent::setUp();
-        
+
         if (!class_exists('Phockito')) {
             $this->skipTest = true;
             return $this->markTestSkipped("These tests need the Phockito module installed to run");
@@ -35,23 +35,20 @@ class SolrIndexVersionedTest extends SapphireTest
 
         SearchUpdater::bind_manipulation_capture();
 
-        Config::nest();
-
         Config::inst()->update('Injector', 'SearchUpdateProcessor', array(
             'class' => 'SearchUpdateImmediateProcessor'
         ));
 
         FullTextSearch::force_index_list(self::$index);
         SearchUpdater::clear_dirty_indexes();
-        
+
         $this->oldMode = Versioned::get_reading_mode();
         Versioned::reading_stage('Stage');
     }
-    
+
     public function tearDown()
     {
         Versioned::set_reading_mode($this->oldMode);
-        Config::unnest();
         parent::tearDown();
     }
 
@@ -59,21 +56,21 @@ class SolrIndexVersionedTest extends SapphireTest
     {
         return Phockito::mock('Solr3Service');
     }
-    
+
     protected function getExpectedDocumentId($id, $stage)
     {
         // Prevent subsites from breaking tests
         $subsites = class_exists('Subsite') ? '"SearchVariantSubsites":"0",' : '';
         return $id.'-SiteTree-{'.$subsites.'"SearchVariantVersioned":"'.$stage.'"}';
     }
-    
+
     public function testPublishing()
     {
-        
+
         // Setup mocks
         $serviceMock = $this->getServiceMock();
         self::$index->setService($serviceMock);
-        
+
         // Check that write updates Stage
         Versioned::reading_stage('Stage');
         Phockito::reset($serviceMock);
@@ -85,7 +82,7 @@ class SolrIndexVersionedTest extends SapphireTest
             'ClassName' => 'SearchVariantVersionedTest_Item'
         ));
         Phockito::verify($serviceMock)->addDocument($doc);
-        
+
         // Check that write updates Live
         Versioned::reading_stage('Stage');
         Phockito::reset($serviceMock);
@@ -99,14 +96,14 @@ class SolrIndexVersionedTest extends SapphireTest
         ));
         Phockito::verify($serviceMock)->addDocument($doc);
     }
-    
+
     public function testDelete()
     {
-        
+
         // Setup mocks
         $serviceMock = $this->getServiceMock();
         self::$index->setService($serviceMock);
-        
+
         // Delete the live record (not the stage)
         Versioned::reading_stage('Stage');
         Phockito::reset($serviceMock);
@@ -121,7 +118,7 @@ class SolrIndexVersionedTest extends SapphireTest
             ->deleteById($this->getExpectedDocumentId($id, 'Live'));
         Phockito::verify($serviceMock, 0)
             ->deleteById($this->getExpectedDocumentId($id, 'Stage'));
-        
+
         // Delete the stage record
         Versioned::reading_stage('Stage');
         Phockito::reset($serviceMock);
@@ -155,7 +152,7 @@ if (!class_exists('Phockito')) {
 class SolrDocumentMatcher extends Hamcrest_BaseMatcher
 {
     protected $properties;
-    
+
     public function __construct($properties)
     {
         $this->properties = $properties;
@@ -171,13 +168,13 @@ class SolrDocumentMatcher extends Hamcrest_BaseMatcher
         if (! ($item instanceof Apache_Solr_Document)) {
             return false;
         }
-        
+
         foreach ($this->properties as $key => $value) {
             if ($item->{$key} != $value) {
                 return false;
             }
         }
-        
+
         return true;
     }
 }


### PR DESCRIPTION
Fixes some regressions in recent framework fixes to versioned.

Also remove unnecessary config nesting in tests which are now handled via core.

Fixes issue I mentioned at https://github.com/silverstripe-labs/silverstripe-fulltextsearch/pull/109#issuecomment-189010025

cc @dhensby , sorry it's late!