### PR TITLE
FIX: Fix initial dev/build on PDO Database.

### DIFF
--- a/code/search/SearchUpdater.php
+++ b/code/search/SearchUpdater.php
@@ -22,7 +22,7 @@ class SearchUpdater extends Object
         global $databaseConfig;
 
         $current = DB::getConn();
-        if (!$current || @$current->isManipulationCapture) {
+        if (!$current || !$current->currentDatabase() || @$current->isManipulationCapture) {
             return;
         } // If not yet set, or its already captured, just return
 


### PR DESCRIPTION
When the database isn’t yet created, $current is set, but
$current->currentDatabase() is empty. I suspect this only applies to 
PDO connections. It results in errors during startup.

This check fixes it.