### PR TITLE
BUG fix issues with search variants applying to more than one class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,35 @@
 # See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
 
-sudo: false
-
 language: php
 
+sudo: false
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
 
 env:
   - DB=MYSQL CORE_RELEASE=3.2
 
 matrix:
   include:
+    - php: 5.3
+      env: DB=PGSQL CORE_RELEASE=3.1
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3
+      env: DB=MYSQL CORE_RELEASE=3.2
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
+      env: DB=MYSQL CORE_RELEASE=3.3 SUBSITES=1
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
+      env: DB=MYSQL CORE_RELEASE=3.3 QUEUEDJOBS=1
 
 before_script:
   - composer self-update || true
   - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+  - "if [ \"$SUBSITES\" = \"\" -a \"$QUEUEDJOBS\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
+  - "if [ \"$SUBSITES\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/subsites; fi"
+  - "if [ \"$QUEUEDJOBS\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/queuedjobs; fi"
   - cd ~/builds/ss
-  - composer install
 
 script:
-  - vendor/bin/phpunit fulltextsearch/tests
+  - vendor/bin/phpunit fulltextsearch/tests/

--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -25,7 +25,7 @@
  * - Specifying which classes and fields this index contains
  *
  * - Specifying update rules that are not extractable from metadata (because the values come from functions for instance)
- * 
+ *
  */
 abstract class SearchIndex extends ViewableData
 {
@@ -354,7 +354,7 @@ abstract class SearchIndex extends ViewableData
 
     /**
      * Returns an array where each member is all the fields and the classes that are at the end of some
-     * specific lookup chain from one of the base classes 
+     * specific lookup chain from one of the base classes
      */
     public function getDerivedFields()
     {
@@ -391,7 +391,7 @@ abstract class SearchIndex extends ViewableData
 
     /**
      * Get the "document ID" (a database & variant unique id) given some "Base" class, DataObject ID and state array
-     * 
+     *
      * @param String $base - The base class of the object
      * @param Integer $id - The ID of the object
      * @param Array $state - The variant state of the object
@@ -465,7 +465,7 @@ abstract class SearchIndex extends ViewableData
                         $method = $step['method'];
                         $object = $object->$method();
                     } elseif ($step['call'] == 'variant') {
-                        $variants = SearchVariant::variants($field['base'], true);
+                        $variants = SearchVariant::variants();
                         $variant = $variants[$step['variant']];
                         $method = $step['method'];
                         $object = $variant->$method($object);
@@ -476,11 +476,26 @@ abstract class SearchIndex extends ViewableData
                 }
             }
         } catch (Exception $e) {
+            static::warn($e);
             $object = null;
         }
 
         restore_error_handler();
         return $object;
+    }
+
+    /**
+     * Log non-fatal errors
+     *
+     * @param Exception $e
+     * @throws Exception
+     */
+    public static function warn($e) {
+        // Noisy errors during testing
+        if(class_exists('SapphireTest', false) && SapphireTest::is_running_test()) {
+            throw $e;
+        }
+        SS_Log::log($e, SS_Log::WARN);
     }
 
     /**
@@ -620,7 +635,7 @@ abstract class SearchIndex_Recording extends SearchIndex
         $res = array();
 
         $res['ID'] = $object->ID;
-        
+
         foreach ($this->getFieldsIterator() as $name => $field) {
             $val = $this->_getFieldValue($object, $field);
             $res[$name] = $val;
@@ -655,7 +670,7 @@ abstract class SearchIndex_Recording extends SearchIndex
     {
         $this->committed = true;
     }
-    
+
     public function getIndexName()
     {
         return get_class($this);

--- a/code/search/SearchVariantSiteTreeSubsitesPolyhome.php
+++ b/code/search/SearchVariantSiteTreeSubsitesPolyhome.php
@@ -40,19 +40,19 @@ class SearchVariantSiteTreeSubsitesPolyhome extends SearchVariant
         }
     }
 
-    public function alterDefinition($base, $index)
+    public function alterDefinition($class, $index)
     {
         $self = get_class($this);
-        
-        $index->filterFields['_subsite'] = array(
+
+        $this->addFilterField($index, '_subsite', array(
             'name' => '_subsite',
             'field' => '_subsite',
             'fullfield' => '_subsite',
-            'base' => $base,
-            'origin' => $base,
+            'base' => ClassInfo::baseDataClass($class),
+            'origin' => $class,
             'type' => 'Int',
             'lookup_chain' => array(array('call' => 'variant', 'variant' => $self, 'method' => 'currentState'))
-        );
+        ));
     }
 
     public function alterQuery($query, $index)

--- a/code/search/SearchVariantVersioned.php
+++ b/code/search/SearchVariantVersioned.php
@@ -25,19 +25,19 @@ class SearchVariantVersioned extends SearchVariant
         Versioned::reading_stage($state);
     }
 
-    public function alterDefinition($base, $index)
+    public function alterDefinition($class, $index)
     {
         $self = get_class($this);
 
-        $index->filterFields['_versionedstage'] = array(
+        $this->addFilterField($index, '_versionedstage', array(
             'name' => '_versionedstage',
             'field' => '_versionedstage',
             'fullfield' => '_versionedstage',
-            'base' => $base,
-            'origin' => $base,
+            'base' => ClassInfo::baseDataClass($class),
+            'origin' => $class,
             'type' => 'String',
             'lookup_chain' => array(array('call' => 'variant', 'variant' => $self, 'method' => 'currentState'))
-        );
+        ));
     }
 
     public function alterQuery($query, $index)
@@ -45,11 +45,11 @@ class SearchVariantVersioned extends SearchVariant
         $stage = Versioned::current_stage();
         $query->filter('_versionedstage', array($stage, SearchQuery::$missing));
     }
-    
+
     public function extractManipulationState(&$manipulation)
     {
         $self = get_class($this);
-        
+
         foreach ($manipulation as $table => $details) {
             $class = $details['class'];
             $stage = 'Stage';

--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -173,7 +173,7 @@ class Solr_BuildTask extends BuildTask
 
     /**
      * Get the current logger
-     * 
+     *
      * @return LoggerInterface
      */
     public function getLogger()
@@ -225,7 +225,7 @@ class Solr_Configure extends Solr_BuildTask
     public function run($request)
     {
         parent::run($request);
-        
+
         // Find the IndexStore handler, which will handle uploading config files to Solr
         $store = $this->getSolrConfigStore();
         $indexes = Solr::get_indexes();
@@ -240,10 +240,10 @@ class Solr_Configure extends Solr_BuildTask
             }
         }
     }
-    
+
     /**
      * Update the index on the given store
-     * 
+     *
      * @param SolrIndex $instance Instance
      * @param SolrConfigStore $store
      */
@@ -251,11 +251,11 @@ class Solr_Configure extends Solr_BuildTask
     {
         $index = $instance->getIndexName();
         $this->getLogger()->info("Configuring $index.");
-        
+
         // Upload the config files for this index
         $this->getLogger()->info("Uploading configuration ...");
         $instance->uploadConfig($store);
-        
+
         // Then tell Solr to use those config files
         $service = Solr::service();
         if ($service->coreIsActive($index)) {
@@ -265,23 +265,23 @@ class Solr_Configure extends Solr_BuildTask
             $this->getLogger()->info("Creating core ...");
             $service->coreCreate($index, $store->instanceDir($index));
         }
-        
+
         $this->getLogger()->info("Done");
     }
 
     /**
      * Get config store
-     * 
+     *
      * @return SolrConfigStore
      */
     protected function getSolrConfigStore()
     {
         $options = Solr::solr_options();
-        
+
         if (!isset($options['indexstore']) || !($indexstore = $options['indexstore'])) {
             user_error('No index configuration for Solr provided', E_USER_ERROR);
         }
-        
+
         // Find the IndexStore handler, which will handle uploading config files to Solr
         $mode = $indexstore['mode'];
 
@@ -340,7 +340,7 @@ class Solr_Reindex extends Solr_BuildTask
     public function run($request)
     {
         parent::run($request);
-        
+
         // Reset state
         $originalState = SearchVariant::current_state();
         $this->doReindex($request);
@@ -411,7 +411,7 @@ class Solr_Reindex extends Solr_BuildTask
     protected function runFrom($index, $class, $start, $variantstate)
     {
         DeprecationTest_Deprecation::notice('2.0.0', 'Solr_Reindex now uses a new grouping mechanism');
-        
+
         // Set time limit and state
         increase_time_limit_to();
         SearchVariant::activate_state($variantstate);

--- a/tests/SolrIndexSubsitesTest.php
+++ b/tests/SolrIndexSubsitesTest.php
@@ -1,0 +1,145 @@
+<?php
+
+if (class_exists('Phockito')) {
+    Phockito::include_hamcrest(false);
+}
+
+/**
+ * Subsite specific solr testing
+ */
+class SolrIndexSubsitesTest extends SapphireTest {
+
+    public static $fixture_file = 'SolrIndexSubsitesTest.yml';
+
+    /**
+     * @var SolrIndexSubsitesTest_Index
+     */
+    private static $index = null;
+
+    protected $server = null;
+
+    public function setUp()
+    {
+        // Prevent parent::setUp() crashing on db build
+        if (!class_exists('Subsite')) {
+            $this->skipTest = true;
+        }
+
+        parent::setUp();
+
+        $this->server = $_SERVER;
+
+        if (!class_exists('Phockito')) {
+            $this->skipTest = true;
+            $this->markTestSkipped("These tests need the Phockito module installed to run");
+            return;
+        }
+
+        // Check versioned available
+        if (!class_exists('Subsite')) {
+            $this->skipTest = true;
+            $this->markTestSkipped('The subsite module is not installed');
+            return;
+        }
+
+        if (self::$index === null) {
+            self::$index = singleton('SolrIndexSubsitesTest_Index');
+        }
+
+        SearchUpdater::bind_manipulation_capture();
+
+        Config::inst()->update('Injector', 'SearchUpdateProcessor', array(
+            'class' => 'SearchUpdateImmediateProcessor'
+        ));
+
+        FullTextSearch::force_index_list(self::$index);
+        SearchUpdater::clear_dirty_indexes();
+    }
+
+    public function tearDown()
+    {
+        if($this->server) {
+            $_SERVER = $this->server;
+            $this->server = null;
+        }
+        parent::tearDown();
+    }
+
+    protected function getServiceMock()
+    {
+        return Phockito::mock('Solr4Service');
+    }
+
+    /**
+     * @param DataObject $object Item being added
+     * @param int $subsiteID
+     * @param string $stage
+     * @return string
+     */
+    protected function getExpectedDocumentId($object, $subsiteID, $stage = null)
+    {
+        $id = $object->ID;
+        $class = ClassInfo::baseDataClass($object);
+        $variants = array();
+
+        // Check subsite
+        if(class_exists('Subsite') && $object->hasOne('Subsite')) {
+            $variants[] = '"SearchVariantSubsites":"' . $subsiteID. '"';
+        }
+
+        // Check versioned
+        if($stage) {
+            $variants[] = '"SearchVariantVersioned":"' . $stage . '"';
+        }
+        return $id.'-'.$class.'-{'.implode(',',$variants).'}';
+    }
+
+    public function testPublishing()
+    {
+        // Setup mocks
+        $serviceMock = $this->getServiceMock();
+        self::$index->setService($serviceMock);
+
+        $subsite1 = $this->objFromFixture('Subsite', 'subsite1');
+
+        // Add records to first subsite
+        Versioned::reading_stage('Stage');
+        $_SERVER['HTTP_HOST'] = 'www.subsite1.com';
+        Phockito::reset($serviceMock);
+        $file = new File();
+        $file->Title = 'My File';
+        $file->SubsiteID = $subsite1->ID;
+        $file->write();
+        $page = new Page();
+        $page->Title = 'My Page';
+        $page->SubsiteID = $subsite1->ID;
+        $page->write();
+        SearchUpdater::flush_dirty_indexes();
+        $doc1 = new SolrDocumentMatcher(array(
+            '_documentid' => $this->getExpectedDocumentId($page, $subsite1->ID, 'Stage'),
+            'ClassName' => 'Page',
+            'SiteTree_Title' => 'My Page',
+            '_versionedstage' => 'Stage',
+            '_subsite' => $subsite1->ID
+        ));
+        $doc2 = new SolrDocumentMatcher(array(
+            '_documentid' => $this->getExpectedDocumentId($file, $subsite1->ID),
+            'ClassName' => 'File',
+            'File_Title' => 'My File',
+            '_subsite' => $subsite1->ID
+        ));
+        Phockito::verify($serviceMock)->addDocument($doc1);
+        Phockito::verify($serviceMock)->addDocument($doc2);
+
+    }
+}
+
+class SolrIndexSubsitesTest_Index extends SolrIndex
+{
+    public function init()
+    {
+        $this->addClass('File');
+        $this->addClass('SiteTree');
+        $this->addAllFulltextFields();
+    }
+}

--- a/tests/SolrIndexSubsitesTest.yml
+++ b/tests/SolrIndexSubsitesTest.yml
@@ -1,0 +1,16 @@
+Subsite:
+  main:
+    Title: Template
+  subsite1:
+    Title: 'Subsite1 Template'
+  subsite2:
+    Title: 'Subsite2 Template'
+SubsiteDomain:
+  subsite1:
+    SubsiteID: =>Subsite.subsite1
+    Domain: www.subsite1.com
+    Protocol: automatic
+  subsite2:
+    SubsiteID: =>Subsite.subsite2
+    Domain: www.subsite2.com
+    Protocol: automatic

--- a/tests/SolrReindexTest.php
+++ b/tests/SolrReindexTest.php
@@ -39,7 +39,7 @@ class SolrReindexTest extends SapphireTest
             $this->skipTest = true;
             return $this->markTestSkipped("These tests need the Phockito module installed to run");
         }
-        
+
         // Set test handler for reindex
         Config::inst()->update('Injector', 'SolrReindexHandler', array(
             'class' => 'SolrReindexTest_TestHandler'
@@ -416,19 +416,19 @@ class SolrReindexTest_Variant extends SearchVariant implements TestOnly
         }
     }
 
-    public function alterDefinition($base, $index)
+    public function alterDefinition($class, $index)
     {
         $self = get_class($this);
 
-        $index->filterFields['_testvariant'] = array(
+        $this->addFilterField($index, '_testvariant', array(
             'name' => '_testvariant',
             'field' => '_testvariant',
             'fullfield' => '_testvariant',
-            'base' => $base,
-            'origin' => $base,
+            'base' => ClassInfo::baseDataClass($class),
+            'origin' => $class,
             'type' => 'Int',
             'lookup_chain' => array(array('call' => 'variant', 'variant' => $self, 'method' => 'currentState'))
-        );
+        ));
     }
 
     public function alterQuery($query, $index)


### PR DESCRIPTION
Plus lots of other fixes:
- Fixed more than one versioned object in an index
- Fixed more than one subsites object in an index
- Fixed SearchVariantSubsites ending up with unflushable (and often invalid) caches of subsites during write
- Fix empty catch blocks from hiding errors during testing
- Add missing abstract alterDefinition to SearchVariant.
- Fix variants assuming that origin === base class for each object type added