### PR TITLE
Add an extension hook to allow altering search results

### DIFF
--- a/code/solr/SolrIndex.php
+++ b/code/solr/SolrIndex.php
@@ -795,7 +795,13 @@ abstract class SolrIndex extends SearchIndex
             }
         }
 
-        return new ArrayData($ret);
+        $ret = new ArrayData($ret);
+
+        // Enable extensions to add extra data from the response into
+        // the returned results set.
+        $this->extend('updateSearchResults', $ret, $res);
+
+        return $ret;
     }
 
 

--- a/docs/en/Solr.md
+++ b/docs/en/Solr.md
@@ -363,17 +363,26 @@ to the page.
 		 *        results pages.
 		 * @param $response The solr-php-client response object.
 		 */
-		function updateSearchResults($results, $response) {
-			$facetCounts = array();
-			if (isset($response->facet_counts)) {
-				foreach ($response->facet_counts as $facet => $count) {
-					$facetCounts[] = new ArrayData(array(
-						'Name' => $facet,
-						'Count' => $count,
-					));
-				}
+		public function updateSearchResults($results, $response)
+		{
+			if (!isset($response->facet_counts) || !isset($response->facet_counts->facet_fields)) {
+				return;
 			}
-			$results->setField('FacetCounts', new ArrayList($facetCounts));
+			$facetCounts = ArrayList::create(array());
+			foreach($response->facet_counts->facet_fields as $name => $facets) {
+				$facetDetails = ArrayData::create(array(
+					'Name' => $name,
+					'Facets' => ArrayList::create(array()),
+				));
+				foreach($facets as $facetName => $facetCount) {
+					$facetDetails->Facets->push(ArrayData::create(array(
+						'Name' => $facetName,
+						'Count' => $facetCount,
+					)));
+				}
+				$facetCounts->push($facetDetails);
+			}
+			$results->setField('FacetCounts', $facetCounts);
 		}
 	}
 


### PR DESCRIPTION
Often I find myself copying the entire search() function from SolrIndex into my custom index classes, so that I can pull some extra information from the solr-php-client into the templates.

I've included some docs on how to use this extension point to add faceting, a common use case.

This change didn't seem to need tests.