### PR TITLE
BUGFIX: Fixed crash when the relationship has no parents

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -557,6 +557,10 @@ abstract class SearchIndex extends ViewableData
 
                         $ids = $sql->execute()->column();
                     }
+                    
+                    if (empty($ids)) {
+                        break;
+                    }
                 }
 
                 SearchVariant::activate_state($current);


### PR DESCRIPTION
When using derived fields if the ids returned from the previous iteration of the [chain loop](https://github.com/silverstripe-labs/silverstripe-fulltextsearch/blob/master/code/search/SearchIndex.php#L547-L560) is empty an SQL error will occur due to the ``IN()`` statement being empty. This pull request simply breaks out of the loop when ``$ids`` is empty.