### PR TITLE
BUGFIX: SolrVersionedTest_Index causing crash in unit tests when Phockito is not installed

### DIFF
--- a/tests/SolrIndexVersionedTest.php
+++ b/tests/SolrIndexVersionedTest.php
@@ -182,6 +182,22 @@ class SolrVersionedTest_Index extends SolrIndex
     }
 }
 
+/**
+ * Non-sitetree versioned dataobject
+ */
+class SolrIndexVersionedTest_Object extends DataObject implements TestOnly {
+
+    private static $extensions = array(
+        'Versioned'
+    );
+
+    private static $db = array(
+        'Title' => 'Varchar',
+        'Content' => 'Text',
+        'TestText' => 'Varchar',
+    );
+}
+
 if (!class_exists('Phockito')) {
     return;
 }
@@ -214,20 +230,4 @@ class SolrDocumentMatcher extends Hamcrest_BaseMatcher
 
         return true;
     }
-}
-
-/**
- * Non-sitetree versioned dataobject
- */
-class SolrIndexVersionedTest_Object extends DataObject implements TestOnly {
-
-    private static $extensions = array(
-        'Versioned'
-    );
-
-    private static $db = array(
-        'Title' => 'Varchar',
-        'Content' => 'Text',
-        'TestText' => 'Varchar',
-    );
 }


### PR DESCRIPTION
When Phockito is not installed the SolrVersionedTest_Index causes an invalid argument exception to be thrown. Stating "Can't add classes which don\'t have data tables (no $db or $has_one set on the class)". This appears to be caused by the return in SolrIndexVersionedTest.php inside of a check for the Phockito class. Moving the SolrIndexVersionedTest_Object class above that check stops the exception. This pull request does that.