### PR TITLE
Remove X-Query, X-Filters, and X-QueryFields headers from being set

### DIFF
--- a/code/solr/SolrIndex.php
+++ b/code/solr/SolrIndex.php
@@ -695,7 +695,7 @@ abstract class SolrIndex extends SearchIndex
             $params['qf'] = $qf;
         }
 
-        if (!headers_sent() && !Director::isLive()) {
+        if (!headers_sent() && Director::isDev()) {
             if ($q) {
                 header('X-Query: '.implode(' ', $q));
             }


### PR DESCRIPTION
Previously these headers were set on dev and test environments, but not live.

Now, they will only be set on dev environments. You can always use `?isDev=1` to force a test or live environment into dev mode (with appropriate permissions).

There's no reason why test should show these headers but live shouldn't - the two envs should be treated the same in this case (otherwise you get security auditors pointing out this 'flaw' which never affects production).

Credit to @timkung who had done this on an earlier version of the module, but the PR was made against the wrong base repository so it never got merged :)