### PR TITLE
FIX Check type is number before pass to setSubsiteId method

### DIFF
--- a/src/Search/Variants/SearchVariantSubsites.php
+++ b/src/Search/Variants/SearchVariantSubsites.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\FullTextSearch\Search\Variants;
 
+use InvalidArgumentException;
 use SilverStripe\Assets\File;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\FullTextSearch\Search\Indexes\SearchIndex;
@@ -69,6 +70,12 @@ class SearchVariantSubsites extends SearchVariant
     {
         if (!$this->appliesToEnvironment()) {
             return;
+        }
+
+        if (is_numeric($state)) {
+            $state = (int) $state;
+        } else {
+            throw new InvalidArgumentException("Invalid state ID. State ID should be number.");
         }
 
         // Note: Setting directly to the SubsiteState because we don't want the subsite ID to be persisted


### PR DESCRIPTION
### Description
- Add checking for passed argument. If `is_numeric` cast to int type value. 
- It fix issue in broken build [here](https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/4179532957/jobs/7239588720#step:12:69)
  > `TypeError: SilverStripe\Subsites\State\SubsiteState::setSubsiteId(): Argument #1 ($id) must be of type ?int, string given, called in /home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/fulltextsearch/src/Search/Variants/SearchVariantSubsites.php on line 76`

### Broken builds
- https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/4179532957/jobs/7239588720

### Parent issue
- https://github.com/silverstripeltd/product-issues/issues/676