### PR TITLE
FIX Always use ?int for subsite state

### DIFF
--- a/src/Search/Variants/SearchVariantSubsites.php
+++ b/src/Search/Variants/SearchVariantSubsites.php
@@ -49,7 +49,7 @@ class SearchVariantSubsites extends SearchVariant
 
     public function currentState()
     {
-        return (string) SubsiteState::singleton()->getSubsiteId();
+        return SubsiteState::singleton()->getSubsiteId();
     }
 
     public function reindexStates()
@@ -74,8 +74,8 @@ class SearchVariantSubsites extends SearchVariant
 
         if (is_numeric($state)) {
             $state = (int) $state;
-        } else {
-            throw new InvalidArgumentException("Invalid state ID. State ID should be number.");
+        } elseif ($state !== null) {
+            throw new InvalidArgumentException("Invalid state ID. State ID should be number or null.");
         }
 
         // Note: Setting directly to the SubsiteState because we don't want the subsite ID to be persisted


### PR DESCRIPTION
Further to https://github.com/silverstripe/silverstripe-fulltextsearch/pull/340 which worked in isolation but still failed in the kitchen sink.

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/4188854627/jobs/7260492591
> InvalidArgumentException: Invalid state ID. State ID should be number.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/676