### PR TITLE
FIX Reset class from the actual SearchVariant instance to respect Injector

### DIFF
--- a/src/Search/Variants/SearchVariant.php
+++ b/src/Search/Variants/SearchVariant.php
@@ -105,6 +105,9 @@ abstract class SearchVariant
                     $ref = new ReflectionClass($variantclass);
                     if ($ref->isInstantiable()) {
                         $variant = singleton($variantclass);
+                        // reassign actual class since Injector could be involved when creating the singleton
+                        $variantclass = get_class($variant);
+
                         if ($variant->appliesToEnvironment()) {
                             $concrete[$variantclass] = $variant;
                         }


### PR DESCRIPTION
Fixes #348 although SearchVariant doesn't explicitly use `Injectable` trait, it uses `ClassInfo` and then `Injector` to create instances of each variant, which can be impacted by `Injector` and produce incorrect list of variants to be applied.

This is a no-harm tweak that addresses this (probably rare) use case.