### PR TITLE
FIX Remove call to process::inheritEnvironmentVariables()

### DIFF
--- a/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
+++ b/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
@@ -104,7 +104,6 @@ class SolrReindexImmediateHandler extends SolrReindexBase
         // Set timeout from config. Process default is 60 seconds
         $process->setTimeout($this->config()->get('process_timeout'));
 
-        $process->inheritEnvironmentVariables();
         $process->run();
 
         $res = $process->getOutput();


### PR DESCRIPTION
inheritEnvironmentVariables() was removed from the Symfony Process component in 5.0.0, as enviroment variables are always inherited. (See https://github.com/symfony/process/blob/5.0/CHANGELOG.md)

Previously I was getting a `[Emergency] Uncaught Error: Call to undefined method Symfony\Component\Process\Process::inheritEnvironmentVariables()` when the immediate reindex handler was called (e.g. when a reindex was run while the site is in dev mode).